### PR TITLE
Fix and clean up some of the backup operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,16 @@ and this project will try its best to adhere to [Semantic Versioning](https://se
 
 ### Additions
 
+* Add spec for database backup command class.
+* Add check on the resulting db dump file. Make sure it's > 0 bytes.
+
 ### Changes
 
 ### Fixes
+
+* Fix typo in backup command class description.
+* Fix backup command to use full database connection string to the database when
+  executing the pg_dump command.
 
 ## [0.5.2]
 

--- a/lib/pgchief.rb
+++ b/lib/pgchief.rb
@@ -50,5 +50,6 @@ module Pgchief
     class UserExistsError < Error; end
     class DatabaseExistsError < Error; end
     class DatabaseMissingError < Error; end
+    class BackupError < Error; end
   end
 end

--- a/spec/pgchief/command/database_backup_spec.rb
+++ b/spec/pgchief/command/database_backup_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pgchief::Command::DatabaseBackup do
+  it "raises an error if the database does not exist" do
+    expect { described_class.new("nonexistent").call }
+      .to raise_error(Pgchief::Errors::DatabaseMissingError)
+  end
+
+  context "when the database exists" do
+    around do |example|
+      Pgchief::Config.backup_dir = "/tmp"
+      Pgchief::Command::DatabaseCreate.new("backup_test").call
+
+      example.run
+
+      Pgchief::Command::DatabaseDrop.new("backup_test").call
+      Dir.glob("/tmp/backup_test-*.dump").each { |f| File.delete(f) }
+    end
+
+    it "backs up the database" do
+      result = described_class.new("backup_test").call
+      message = %r{Database 'backup_test' backed up to /tmp/.*.dump}
+
+      expect(result).to match(message)
+    end
+
+    it "raises an error if the backup file is 0 bytes" do
+      allow(File).to receive(:size?).and_return(nil)
+
+      expect { described_class.new("backup_test").call }
+        .to raise_error(Pgchief::Errors::BackupError)
+    end
+  end
+end


### PR DESCRIPTION
* Add spec for database backup command class.
* Add check on the resulting db dump file. Make sure it's > 0 bytes.

* Fix typo in backup command class description.
* Fix backup command to use full database connection string to the database when executing the pg_dump command.
